### PR TITLE
[FIX][Android] 신고 바텀시트 및 키보드 대응 UI 오류 수정

### DIFF
--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -50,7 +50,7 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
           {scrollEnabled ? (
             <ScrollView
               style={styles.scrollView}
-              contentContainerStyle={styles.content}
+              contentContainerStyle={[styles.content, { flexGrow: 1 }]}
               showsVerticalScrollIndicator={false}
             >
               {children}

--- a/src/components/common/ReportBottomSheet.tsx
+++ b/src/components/common/ReportBottomSheet.tsx
@@ -227,6 +227,7 @@ const styles = StyleSheet.create({
     paddingVertical: verticalScale(14.5),
   },
   reasonText: {
+    flex: 1,
     marginLeft: scale(13),
   },
   inputContainer: {

--- a/src/components/common/ReportBottomSheet.tsx
+++ b/src/components/common/ReportBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, StyleSheet, TouchableOpacity, TextInput, Platform, Keyboard, Alert, KeyboardAvoidingView } from 'react-native';
 import { scale, verticalScale, moderateScale } from '../../utils/scaling';
 import { BottomSheet } from './BottomSheet';
@@ -26,6 +26,41 @@ export const ReportBottomSheet: React.FC<ReportBottomSheetProps> = ({
   const [reportReasonDetail, setReportReasonDetail] = useState('');
   const [isTextInputMode, setIsTextInputMode] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [bottomSheetHeight, setBottomSheetHeight] = useState(560);
+  const [isKeyboardActive, setIsKeyboardActive] = useState(false);
+
+  useEffect(() => {
+    // 텍스트 입력 모드가 아니거나 iOS인 경우 로직 미적용 (iOS는 고정 높이 유지)
+    if (!isTextInputMode || Platform.OS === 'ios') {
+      setBottomSheetHeight(560);
+      setIsKeyboardActive(false);
+      return;
+    }
+
+    const showEvent = 'keyboardDidShow';
+    const hideEvent = 'keyboardDidHide';
+
+    const keyboardShowListener = Keyboard.addListener(
+      showEvent,
+      (e) => {
+        // 안드로이드에서는 키보드 높이만큼 바텀시트 높이 줄이기
+        setBottomSheetHeight(560 - e.endCoordinates.height + 100);
+        setIsKeyboardActive(true);
+      }
+    );
+    const keyboardHideListener = Keyboard.addListener(
+      hideEvent,
+      () => {
+        setBottomSheetHeight(560);
+        setIsKeyboardActive(false);
+      }
+    );
+
+    return () => {
+      keyboardShowListener.remove();
+      keyboardHideListener.remove();
+    };
+  }, [isTextInputMode]);
 
   // 신고 사유 목록
   const reportReasons: Array<{ label: string; value: ReportReason }> = [
@@ -45,7 +80,7 @@ export const ReportBottomSheet: React.FC<ReportBottomSheetProps> = ({
   // 신고 버튼 활성화 여부
   const isReportButtonEnabled = () => {
     if (!selectedReportReason) return false;
-    // 기타 선택 시 텍스트 입력 모드일 때는 글자가 있어야 함
+    // 기타 선택 시 텍스트 입력 모드일 때는 입력된 텍스트가 있어야 함
     if (isTextInputMode) {
       return reportReasonDetail.trim().length > 0;
     }
@@ -123,12 +158,12 @@ export const ReportBottomSheet: React.FC<ReportBottomSheetProps> = ({
   return (
     <BottomSheet
       visible={visible}
-      height={560}
-      scrollEnabled={false}
+      height={bottomSheetHeight}
+      scrollEnabled={isTextInputMode}
       onClose={handleClose}
     >
       <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         style={{ flex: 1 }}
       >
         <View style={styles.content}>
@@ -141,7 +176,10 @@ export const ReportBottomSheet: React.FC<ReportBottomSheetProps> = ({
             {isTextInputMode ? (
               /* 기타 선택 시 텍스트 입력 필드 */
               <>
-                <View style={styles.inputContainer}>
+                <View style={[
+                  styles.inputContainer,
+                  !isKeyboardActive && { height: verticalScale(280) } // 키보드 없을 땐 입력창을 더 크게
+                ]}>
                   <TextInput
                     style={styles.input}
                     placeholder="최대 200자까지 작성 가능합니다."
@@ -155,6 +193,10 @@ export const ReportBottomSheet: React.FC<ReportBottomSheetProps> = ({
                     returnKeyType="done"
                     blurOnSubmit={true}
                     onSubmitEditing={() => Keyboard.dismiss()}
+                    onBlur={() => {
+                      setBottomSheetHeight(560);
+                      setIsKeyboardActive(false);
+                    }}
                   />
                 </View>
                 <Text variant="xsReg" color={colors.text.tertiary} style={styles.characterCount}>

--- a/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
@@ -45,6 +45,10 @@ type ChallengeCertificationDetailScreenNavigationProp = StackNavigationProp<
   'ChallengeCertificationDetail'
 >;
 
+// 플랫폼별 키보드 오프셋
+const KEYBOARD_OFFSET_IOS = 0;
+const KEYBOARD_OFFSET_ANDROID = 15;
+
 export const ChallengeCertificationDetailScreen: React.FC = () => {
   const navigation = useNavigation<ChallengeCertificationDetailScreenNavigationProp>();
   const route = useRoute<ChallengeCertificationDetailScreenRouteProp>();
@@ -736,13 +740,16 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
 
       {/* 댓글 입력 필드 */}
       <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 0}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? KEYBOARD_OFFSET_IOS : 0}
         style={styles.keyboardAvoidingView}
       >
         <View style={[
           styles.commentInputContainer,
-          isKeyboardVisible && styles.commentInputContainerKeyboard
+          isKeyboardVisible && styles.commentInputContainerKeyboard,
+          Platform.OS === 'android' && isKeyboardVisible && {
+            bottom: keyboardHeight + KEYBOARD_OFFSET_ANDROID,
+          }
         ]}>
           <TextField
             ref={commentInputRef}


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
Android 환경에서 UI가 의도와 다르게 동작하던 문제들을 해결했습니다.

## 🔗 관련 이슈
close #29 
<!-- 참고용: ref #이슈번호 -->

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [ ] 새로운 기능
- [x] 버그 수정
- [x] UI/UX 개선
- [ ] 리팩토링
- [ ] 의존성 변경

## 📸 스크린샷
### 갤럭시 S21 (실기기)
| 1 | 2 | 3 |
|---|---|---|
|<img width="300" height="2400" alt="image" src="https://github.com/user-attachments/assets/4a09a5b2-dba4-4918-af84-bbab5219354f" />|<img width="300" height="2400" alt="image" src="https://github.com/user-attachments/assets/789b2be7-7e48-4443-94ea-2efdc30135e7" />|<img width="300" height="2400" alt="image" src="https://github.com/user-attachments/assets/344d0455-b432-4f0f-831d-2d244fc268a1" />|


## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
- 현재 신고 바텀시트에서 텍스트 입력 시 키보드 동작 방식에서 차이가 있는데, iOS와 Android는 키보드 동작 방식이 근본적으로 달라(`Window Resize` vs. `Overlay`) 단일 방식으로 완전히 통일하기에는 어려움이 있었습니다.
- 따라서 현재는 각 플랫폼의 기본 UX에 따른 분기 처리 방식이 가장 간편하고 안정적인 해결책이라고 판단하여 이와 같이 작업하였으나, 추후 여유가 생기면 `react-native-keyboard-controller` 라이브러리를 기반으로 리팩토링하도록 하겠습니다



