### PR TITLE
[FEAT] 검색 탭 UI 구현 및 API 연동

### DIFF
--- a/src/libs/api/search.ts
+++ b/src/libs/api/search.ts
@@ -1,0 +1,26 @@
+import { apiClient } from './client';
+
+interface ApiResponse<T> {
+  isSuccess: boolean;
+  status: string;
+  code: string;
+  message: string;
+  result: T;
+}
+
+// 검색 카운트 증가
+export const incrementSearchCount = async (keyword: string): Promise<ApiResponse<{}>> => {
+  const response = await apiClient.post<ApiResponse<{}>>('/api/v1/search/count', null, {
+    params: {
+      keyword,
+    },
+  });
+  return response.data;
+};
+
+// 인기 검색어 조회
+export const getPopularKeywords = async (): Promise<ApiResponse<string[]>> => {
+  const response = await apiClient.get<ApiResponse<string[]>>('/api/v1/search/popular-keyword');
+  return response.data;
+};
+

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -9,6 +9,7 @@ import HomeScreen from '../screens/HomeScreen';
 import NotificationsScreen from '../screens/NotificationsScreen';
 import ChallengeListScreen from '../screens/ChallengeListScreen';
 import RandomMissionScreen from '../screens/RandomMissionScreen';
+import CategorySearchScreen from '../screens/CategorySearchScreen';
 import SearchScreen from '../screens/SearchScreen';
 import ChatScreen from '../screens/ChatScreen';
 import MyScreen from '../screens/MyScreen';
@@ -93,7 +94,7 @@ const RootNavigator = ({ showRecommendation = false }: { showRecommendation?: bo
         <Stack.Screen name="ChallengeCertificationEdit" component={ChallengeCertificationEditScreen} options={{ headerShown: false }} />
         <Stack.Screen name="ChallengeCertificationTextEdit" component={ChallengeCertificationTextEditScreen} options={{ headerShown: false }} />
         <Stack.Screen name="PopularChallenge" component={PopularChallengeScreen} options={{ headerShown: false }} />
-        <Stack.Screen name="Search" component={SearchScreen} options={{ headerShown: false }} />
+        <Stack.Screen name="Search" component={CategorySearchScreen} options={{ headerShown: false }} />
         <Stack.Screen name="CreateChallengeQ1" component={CreateChallengeQ1} options={{ headerShown: false }} />
         <Stack.Screen name="CreateChallengeQ2" component={CreateChallengeQ2} options={{ headerShown: false }} />
         <Stack.Screen name="CreateChallengeQ3" component={CreateChallengeQ3} options={{ headerShown: false }} />

--- a/src/screens/CategorySearchScreen.tsx
+++ b/src/screens/CategorySearchScreen.tsx
@@ -19,10 +19,10 @@ import DeleteCircleIcon from '../../assets/icons/delete-circle.svg';
 const RECENT_SEARCHES_KEY = 'recentSearches';
 const MAX_RECENT_SEARCHES = 20;
 
-type SearchScreenNavigationProp = StackNavigationProp<RootStackParamList>;
+type CategorySearchScreenNavigationProp = StackNavigationProp<RootStackParamList>;
 
-const SearchScreen = () => {
-  const navigation = useNavigation<SearchScreenNavigationProp>();
+const CategorySearchScreen = () => {
+  const navigation = useNavigation<CategorySearchScreenNavigationProp>();
   const insets = useSafeAreaInsets();
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<ChallengeInfo[]>([]);
@@ -399,4 +399,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default SearchScreen;
+export default CategorySearchScreen;

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -19,7 +19,7 @@ import DeleteCircleIcon from '../../assets/icons/delete-circle.svg';
 
 type SearchScreenNavigationProp = StackNavigationProp<RootStackParamList>;
 
-const RECENT_SEARCHES_KEY = 'tabSearchRecentSearches';
+const RECENT_SEARCHES_KEY = 'recentSearches'; // CategorySearchScreen과 공유
 const MAX_RECENT_SEARCHES = 20;
 
 const SearchScreen = () => {

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -1,0 +1,550 @@
+import React, { useState, useEffect } from 'react';
+import { View, StyleSheet, TouchableOpacity, ScrollView, TextInput, Platform } from 'react-native';
+import { scale, verticalScale, moderateScale } from '../utils/scaling';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { RootStackParamList } from '../navigation/types';
+import { colors, typography } from '../design/tokens';
+import { Text } from '../components/common/Text';
+import { getChallenges, ChallengeInfo, trackChallengeClick } from '../libs/api/challenge';
+import ChallengeItem from '../components/common/ChallengeItem';
+import LogoGray from '../../assets/images/logo-gray.svg';
+import BackIcon from '../../assets/icons/back.svg';
+import SearchIcon from '../../assets/icons/search.svg';
+import DeleteIcon from '../../assets/icons/delete.svg';
+import DeleteCircleIcon from '../../assets/icons/delete-circle.svg';
+
+type SearchScreenNavigationProp = StackNavigationProp<RootStackParamList>;
+
+const RECENT_SEARCHES_KEY = 'tabSearchRecentSearches'; // CategorySearchScreen과 다른 키 사용
+const MAX_RECENT_SEARCHES = 20;
+
+// 더미 인기 검색어 데이터 (추후 API 연동)
+const POPULAR_SEARCHES = [
+  '코딩테스트',
+  '코테',
+  '토스',
+  '건기',
+  '산책',
+  '네이버',
+  '카카오',
+  '케이뱅크',
+  '다이어리',
+  '독서',
+];
+
+const SearchScreen = () => {
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation<SearchScreenNavigationProp>();
+
+  const [isSearchMode, setIsSearchMode] = useState(false); // 검색 모드 여부
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<ChallengeInfo[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+
+  const topPadding = Platform.OS === 'android' ? verticalScale(18) : verticalScale(10);
+  const bottomPadding = verticalScale(4);
+  const safeAreaTop = Platform.OS === 'android' ? Math.max(insets.top, verticalScale(24)) : insets.top;
+
+  // AsyncStorage에서 최근 검색어 불러오기
+  useEffect(() => {
+    const loadRecentSearches = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(RECENT_SEARCHES_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          if (Array.isArray(parsed)) {
+            setRecentSearches(parsed);
+          }
+        }
+      } catch (error) {
+        // 최근 검색어 불러오기 실패
+      }
+    };
+
+    loadRecentSearches();
+  }, []);
+
+  // 최근 검색어를 AsyncStorage에 저장
+  const saveRecentSearches = async (searches: string[]) => {
+    try {
+      await AsyncStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(searches));
+    } catch (error) {
+      // 최근 검색어 저장 실패
+    }
+  };
+
+  // 요일 파싱 함수
+  const parseDaysOfWeek = (daysData: string | string[]) => {
+    try {
+      let days: string[] = [];
+
+      if (Array.isArray(daysData)) {
+        days = daysData;
+      } else if (typeof daysData === 'string') {
+        const validJson = daysData.replace(/'/g, '"');
+        days = JSON.parse(validJson);
+      }
+
+      if (Array.isArray(days)) {
+        if (days.length === 7) return '매일';
+
+        const dayMap: Record<string, string> = {
+          MONDAY: '월', TUESDAY: '화', WEDNESDAY: '수', THURSDAY: '목',
+          FRIDAY: '금', SATURDAY: '토', SUNDAY: '일'
+        };
+
+        return days.map(d => dayMap[d] || d).join(' / ');
+      }
+      return '매일';
+    } catch (e) {
+      return '매일';
+    }
+  };
+
+  // 검색어 삭제 함수
+  const handleDeleteSearch = async (index: number) => {
+    const updated = recentSearches.filter((_, i) => i !== index);
+    setRecentSearches(updated);
+    await saveRecentSearches(updated);
+  };
+
+  // 검색 입력 필드 초기화 함수
+  const handleClearSearch = () => {
+    setSearchQuery('');
+    setSearchResults([]);
+    setHasSearched(false);
+  };
+
+  // 뒤로가기 (인기 검색어 모드로 복귀)
+  const handleBackToPopular = () => {
+    setIsSearchMode(false);
+    setSearchQuery('');
+    setSearchResults([]);
+    setHasSearched(false);
+  };
+
+  // 검색 API 호출
+  const handleSearch = async (query?: string) => {
+    const searchTerm = query !== undefined ? query : (searchQuery || '');
+    const trimmedQuery = typeof searchTerm === 'string' ? searchTerm.trim() : '';
+
+    if (!trimmedQuery) {
+      return;
+    }
+
+    if (query !== undefined) {
+      setSearchQuery(query);
+    }
+
+    setIsSearching(true);
+    setHasSearched(true);
+
+    try {
+      const searchParams = {
+        title: trimmedQuery,
+        page: 1,
+        size: 20,
+      };
+
+      const result = await getChallenges(searchParams);
+      setSearchResults(result.content);
+
+      // 최근 검색어 저장
+      const updated = [trimmedQuery, ...recentSearches.filter(s => s !== trimmedQuery)].slice(0, MAX_RECENT_SEARCHES);
+      setRecentSearches(updated);
+      await saveRecentSearches(updated);
+    } catch (error) {
+      setSearchResults([]);
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  // 인기 검색어 클릭 핸들러
+  const handlePopularSearchClick = (keyword: string) => {
+    setIsSearchMode(true);
+    setSearchQuery(keyword);
+    handleSearch(keyword);
+  };
+
+  // 인기 검색어 두 그룹으로 나누기 (1-5위, 6-10위)
+  const leftColumn = POPULAR_SEARCHES.slice(0, 5);
+  const rightColumn = POPULAR_SEARCHES.slice(5, 10);
+
+  // 검색 모드일 때 UI
+  if (isSearchMode) {
+    return (
+      <View style={styles.searchModeContainer}>
+        {/* 검색 헤더 */}
+        <View style={[
+          styles.searchHeader,
+          {
+            paddingTop: safeAreaTop + topPadding,
+            paddingBottom: bottomPadding,
+          }
+        ]}>
+          {/* 뒤로가기 버튼 */}
+          <TouchableOpacity
+            onPress={handleBackToPopular}
+            style={styles.backButton}
+            hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+          >
+            <BackIcon width={9} height={18} />
+          </TouchableOpacity>
+
+          {/* 검색 입력 필드 */}
+          <View style={[styles.searchInputContainer, styles.searchInputContainerActive]}>
+            <View style={styles.searchIconContainer}>
+              <SearchIcon width={12} height={15.77} />
+            </View>
+            <TextInput
+              style={styles.searchInput}
+              placeholder="찾으시는 검색 내용이 있나요?"
+              placeholderTextColor={colors.icon.gray}
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+              onSubmitEditing={() => handleSearch()}
+              returnKeyType="search"
+              autoFocus={true}
+            />
+            {searchQuery.length > 0 && (
+              <TouchableOpacity
+                onPress={handleClearSearch}
+                style={styles.clearButton}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              >
+                <DeleteCircleIcon width={12} height={12} />
+              </TouchableOpacity>
+            )}
+          </View>
+        </View>
+
+        {/* 검색 결과 또는 최근 검색어 섹션 */}
+        <ScrollView
+          style={styles.content}
+          contentContainerStyle={[
+            styles.contentContainer,
+            hasSearched && searchResults.length === 0 && !isSearching && styles.whiteBackground
+          ]}
+        >
+          {hasSearched ? (
+            // 검색 결과 표시
+            <>
+              {isSearching ? (
+                <View style={styles.emptyContainer}>
+                  <Text variant="smReg" color={colors.text.tertiary}>
+                    검색 중...
+                  </Text>
+                </View>
+              ) : searchResults.length > 0 ? (
+                <View style={styles.resultsContainer}>
+                  {searchResults.map((challenge, index) => {
+                    const daysText = parseDaysOfWeek(challenge.daysOfWeek);
+                    const isLast = index === searchResults.length - 1;
+
+                    return (
+                      <ChallengeItem
+                        key={challenge.challengeId}
+                        challengeId={challenge.challengeId}
+                        thumbnailUrl={challenge.thumbnailUrl}
+                        title={challenge.title}
+                        description={challenge.description}
+                        daysText={daysText}
+                        currentParticipantCount={challenge.currentParticipantCount}
+                        maxParticipantCount={challenge.maxParticipantCount}
+                        ddayUntilStart={challenge.ddayUntilStart}
+                        onPress={() => {
+                          trackChallengeClick(challenge.challengeId);
+                          navigation.navigate('ChallengeProfile', { challengeId: challenge.challengeId });
+                        }}
+                        marginBottom={isLast ? 0 : 8}
+                        marginHorizontal={0}
+                      />
+                    );
+                  })}
+                </View>
+              ) : (
+                <View style={styles.emptyContainer}>
+                  <LogoGray width={124.16} height={119.79} />
+                  <Text style={styles.emptyText}>
+                    검색어에 맞는 결과가 없어요
+                  </Text>
+                </View>
+              )}
+            </>
+          ) : (
+            // 최근 검색어 표시
+            <View style={styles.recentSearchContainer}>
+              <Text variant="header4" color={colors.text.primary} style={styles.sectionTitle}>
+                최근 검색어
+              </Text>
+              {recentSearches.length > 0 ? (
+                <View style={styles.searchList}>
+                  {recentSearches.map((search, index) => (
+                    <View key={index} style={styles.searchItem}>
+                      <TouchableOpacity
+                        style={styles.searchItemContent}
+                        onPress={() => handleSearch(search)}
+                      >
+                        <Text variant="smReg" color={colors.text.primary} style={styles.searchText}>
+                          {search}
+                        </Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        onPress={() => handleDeleteSearch(index)}
+                        style={styles.deleteButton}
+                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                      >
+                        <DeleteIcon width={12} height={12} />
+                      </TouchableOpacity>
+                    </View>
+                  ))}
+                </View>
+              ) : (
+                <Text variant="smReg" color={colors.icon.gray}>
+                  최근 검색어가 없습니다
+                </Text>
+              )}
+            </View>
+          )}
+        </ScrollView>
+      </View>
+    );
+  }
+
+  // 인기 검색어 모드일 때 UI (초기 진입 화면)
+  return (
+    <View style={styles.container}>
+      {/* 헤더 영역 */}
+      <View style={[styles.header, {
+        paddingTop: safeAreaTop + topPadding,
+        paddingBottom: bottomPadding
+      }]}>
+        <Text variant="header1" color={colors.text.primary} style={styles.headerTitle}>
+          검색
+        </Text>
+      </View>
+
+      {/* 검색 필드 */}
+      <TouchableOpacity
+        style={styles.searchContainer}
+        onPress={() => setIsSearchMode(true)}
+        activeOpacity={0.8}
+      >
+        <View style={styles.searchInputContainer}>
+          <View style={styles.searchIconContainer}>
+            <SearchIcon width={12} height={15.77} />
+          </View>
+          <Text variant="smReg" color={colors.icon.gray} style={styles.searchPlaceholder}>
+            찾으시는 검색 내용이 있나요?
+          </Text>
+        </View>
+      </TouchableOpacity>
+
+      {/* 인기 검색어 섹션 */}
+      <ScrollView style={styles.content} contentContainerStyle={styles.contentContainer}>
+        <View style={styles.popularSearchSection}>
+          <Text variant="header3" color={colors.text.primary} style={styles.popularTitle}>
+            인기 검색어
+          </Text>
+
+          <View style={styles.popularListContainer}>
+            {/* 왼쪽 열 (1-5위) */}
+            <View style={styles.column}>
+              {leftColumn.map((keyword, index) => (
+                <TouchableOpacity
+                  key={`left-${index}`}
+                  style={styles.popularItem}
+                  onPress={() => handlePopularSearchClick(keyword)}
+                  activeOpacity={0.7}
+                >
+                  <View style={styles.rankContainer}>
+                    <Text variant="header4" color={colors.primary.main}>
+                      {index + 1}
+                    </Text>
+                  </View>
+                  <Text variant="xsReg" color={colors.text.primary} style={styles.keywordText}>
+                    {keyword}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+
+            {/* 오른쪽 열 (6-10위) */}
+            <View style={styles.column}>
+              {rightColumn.map((keyword, index) => (
+                <TouchableOpacity
+                  key={`right-${index}`}
+                  style={styles.popularItem}
+                  onPress={() => handlePopularSearchClick(keyword)}
+                  activeOpacity={0.7}
+                >
+                  <View style={styles.rankContainer}>
+                    <Text variant="header4" color={colors.primary.main}>
+                      {index + 6}
+                    </Text>
+                  </View>
+                  <Text variant="xsReg" color={colors.text.primary} style={styles.keywordText}>
+                    {keyword}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.white,
+  },
+  header: {
+    paddingHorizontal: scale(24),
+    backgroundColor: colors.white,
+  },
+  headerTitle: {
+  },
+  searchHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: scale(24),
+    backgroundColor: colors.white,
+  },
+  backButton: {
+    width: scale(24),
+    height: verticalScale(24),
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: scale(12),
+  },
+  searchModeContainer: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  searchContainer: {
+    paddingHorizontal: scale(24),
+    paddingTop: verticalScale(15),
+    backgroundColor: colors.white,
+  },
+  searchInputContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.background,
+    borderRadius: scale(10),
+    paddingHorizontal: scale(10),
+    height: verticalScale(44),
+  },
+  searchInputContainerActive: {
+    flex: 1,
+  },
+  searchIconContainer: {
+    marginRight: scale(8),
+  },
+  searchInput: {
+    flex: 1,
+    ...typography.smReg,
+    color: colors.text.primary,
+    padding: 0,
+  },
+  searchPlaceholder: {
+    flex: 1,
+    padding: 0,
+  },
+  clearButton: {
+    width: scale(24),
+    height: verticalScale(24),
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginLeft: scale(8),
+  },
+  content: {
+    flex: 1,
+  },
+  contentContainer: {
+    paddingHorizontal: scale(24),
+    paddingBottom: verticalScale(40),
+  },
+  popularSearchSection: {
+    marginTop: verticalScale(32),
+  },
+  popularTitle: {
+    marginBottom: verticalScale(21),
+  },
+  popularListContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  column: {
+    flex: 1,
+    gap: verticalScale(13),
+  },
+  popularItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  rankContainer: {
+    width: scale(20),
+    height: verticalScale(19),
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  keywordText: {
+    marginLeft: scale(10),
+    lineHeight: moderateScale(13),
+  },
+  resultsContainer: {
+    marginTop: verticalScale(24),
+  },
+  recentSearchContainer: {
+    marginTop: verticalScale(24),
+  },
+  sectionTitle: {
+    marginBottom: verticalScale(16),
+  },
+  searchList: {
+    marginLeft: scale(4),
+  },
+  searchItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: verticalScale(10),
+  },
+  searchItemContent: {
+    flex: 1,
+  },
+  searchText: {
+    flex: 1,
+  },
+  deleteButton: {
+    width: scale(24),
+    height: verticalScale(24),
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  emptyContainer: {
+    alignItems: 'center',
+    paddingTop: verticalScale(228),
+  },
+  emptyText: {
+    ...typography.smReg,
+    color: colors.icon.gray,
+    textAlign: 'center',
+    marginTop: verticalScale(32),
+  },
+  whiteBackground: {
+    backgroundColor: colors.white,
+    flex: 1,
+  },
+});
+
+export default SearchScreen;

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { View, StyleSheet, TouchableOpacity, ScrollView, TextInput, Platform } from 'react-native';
 import { scale, verticalScale, moderateScale } from '../utils/scaling';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { RootStackParamList } from '../navigation/types';
@@ -50,7 +50,7 @@ const SearchScreen = () => {
     }
   };
 
-  // AsyncStorage에서 최근 검색어 불러오기 + 인기 검색어 API 호출
+  // AsyncStorage에서 최근 검색어 불러오기
   useEffect(() => {
     const loadRecentSearches = async () => {
       try {
@@ -67,8 +67,14 @@ const SearchScreen = () => {
     };
 
     loadRecentSearches();
-    loadPopularKeywords();
   }, []);
+
+  // 화면이 포커스될 때마다 인기 검색어 새로 불러오기
+  useFocusEffect(
+    useCallback(() => {
+      loadPopularKeywords();
+    }, [])
+  );
 
   // 최근 검색어를 AsyncStorage에 저장
   const saveRecentSearches = async (searches: string[]) => {

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -2,12 +2,14 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { View, StyleSheet, TouchableOpacity, ScrollView, TextInput, Platform } from 'react-native';
 import { scale, verticalScale, moderateScale } from '../utils/scaling';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import { useNavigation, useFocusEffect, CompositeNavigationProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { RootStackParamList } from '../navigation/types';
+import { RootStackParamList, HomeTabParamList } from '../navigation/types';
 import { colors, typography } from '../design/tokens';
 import { Text } from '../components/common/Text';
+// ... 나머지 import는 그대로 유지 ...
 import { getChallenges, ChallengeInfo, trackChallengeClick } from '../libs/api/challenge';
 import { getPopularKeywords, incrementSearchCount } from '../libs/api/search';
 import ChallengeItem from '../components/common/ChallengeItem';
@@ -17,7 +19,10 @@ import SearchIcon from '../../assets/icons/search.svg';
 import DeleteIcon from '../../assets/icons/delete.svg';
 import DeleteCircleIcon from '../../assets/icons/delete-circle.svg';
 
-type SearchScreenNavigationProp = StackNavigationProp<RootStackParamList>;
+type SearchScreenNavigationProp = CompositeNavigationProp<
+  BottomTabNavigationProp<HomeTabParamList, '검색'>,
+  StackNavigationProp<RootStackParamList>
+>;
 
 const RECENT_SEARCHES_KEY = 'recentSearches'; // CategorySearchScreen과 공유
 const MAX_RECENT_SEARCHES = 20;
@@ -33,6 +38,14 @@ const SearchScreen = () => {
   const [hasSearched, setHasSearched] = useState(false);
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [popularSearches, setPopularSearches] = useState<string[]>([]);
+
+  // 뒤로가기 (인기 검색어 모드로 복귀)
+  const handleBackToPopular = useCallback(() => {
+    setIsSearchMode(false);
+    setSearchQuery('');
+    setSearchResults([]);
+    setHasSearched(false);
+  }, []);
 
   const topPadding = Platform.OS === 'android' ? verticalScale(18) : verticalScale(10);
   const bottomPadding = verticalScale(4);
@@ -75,6 +88,18 @@ const SearchScreen = () => {
       loadPopularKeywords();
     }, [])
   );
+
+  // 검색 탭을 다시 누르면 초기 화면으로 리셋
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('tabPress', (e) => {
+      // 현재 화면이 포커스된 상태에서 검색 탭을 누른 경우
+      if (navigation.isFocused()) {
+        handleBackToPopular();
+      }
+    });
+
+    return unsubscribe;
+  }, [navigation, handleBackToPopular]);
 
   // 최근 검색어를 AsyncStorage에 저장
   const saveRecentSearches = async (searches: string[]) => {
@@ -122,14 +147,6 @@ const SearchScreen = () => {
 
   // 검색 입력 필드 초기화 함수
   const handleClearSearch = () => {
-    setSearchQuery('');
-    setSearchResults([]);
-    setHasSearched(false);
-  };
-
-  // 뒤로가기 (인기 검색어 모드로 복귀)
-  const handleBackToPopular = () => {
-    setIsSearchMode(false);
     setSearchQuery('');
     setSearchResults([]);
     setHasSearched(false);

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -9,6 +9,7 @@ import { RootStackParamList } from '../navigation/types';
 import { colors, typography } from '../design/tokens';
 import { Text } from '../components/common/Text';
 import { getChallenges, ChallengeInfo, trackChallengeClick } from '../libs/api/challenge';
+import { getPopularKeywords, incrementSearchCount } from '../libs/api/search';
 import ChallengeItem from '../components/common/ChallengeItem';
 import LogoGray from '../../assets/images/logo-gray.svg';
 import BackIcon from '../../assets/icons/back.svg';
@@ -18,22 +19,8 @@ import DeleteCircleIcon from '../../assets/icons/delete-circle.svg';
 
 type SearchScreenNavigationProp = StackNavigationProp<RootStackParamList>;
 
-const RECENT_SEARCHES_KEY = 'tabSearchRecentSearches'; // CategorySearchScreen과 다른 키 사용
+const RECENT_SEARCHES_KEY = 'tabSearchRecentSearches';
 const MAX_RECENT_SEARCHES = 20;
-
-// 더미 인기 검색어 데이터 (추후 API 연동)
-const POPULAR_SEARCHES = [
-  '코딩테스트',
-  '코테',
-  '토스',
-  '건기',
-  '산책',
-  '네이버',
-  '카카오',
-  '케이뱅크',
-  '다이어리',
-  '독서',
-];
 
 const SearchScreen = () => {
   const insets = useSafeAreaInsets();
@@ -45,12 +32,25 @@ const SearchScreen = () => {
   const [isSearching, setIsSearching] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const [popularSearches, setPopularSearches] = useState<string[]>([]);
 
   const topPadding = Platform.OS === 'android' ? verticalScale(18) : verticalScale(10);
   const bottomPadding = verticalScale(4);
   const safeAreaTop = Platform.OS === 'android' ? Math.max(insets.top, verticalScale(24)) : insets.top;
 
-  // AsyncStorage에서 최근 검색어 불러오기
+  // 인기 검색어 불러오기 함수
+  const loadPopularKeywords = async () => {
+    try {
+      const response = await getPopularKeywords();
+      if (response.isSuccess && Array.isArray(response.result)) {
+        setPopularSearches(response.result);
+      }
+    } catch (error) {
+      // 인기 검색어 불러오기 실패
+    }
+  };
+
+  // AsyncStorage에서 최근 검색어 불러오기 + 인기 검색어 API 호출
   useEffect(() => {
     const loadRecentSearches = async () => {
       try {
@@ -67,6 +67,7 @@ const SearchScreen = () => {
     };
 
     loadRecentSearches();
+    loadPopularKeywords();
   }, []);
 
   // 최근 검색어를 AsyncStorage에 저장
@@ -145,6 +146,16 @@ const SearchScreen = () => {
     setHasSearched(true);
 
     try {
+      // 검색 카운트 증가 API 호출 (성공 시 인기 검색어 갱신)
+      incrementSearchCount(trimmedQuery)
+        .then(() => {
+          // 인기 검색어 목록 갱신 (서버에서 1시간 단위로 업데이트됨)
+          loadPopularKeywords();
+        })
+        .catch(() => {
+          // 검색 카운트 증가 실패 (검색 기능은 정상적으로 동작)
+        });
+
       const searchParams = {
         title: trimmedQuery,
         page: 1,
@@ -173,8 +184,8 @@ const SearchScreen = () => {
   };
 
   // 인기 검색어 두 그룹으로 나누기 (1-5위, 6-10위)
-  const leftColumn = POPULAR_SEARCHES.slice(0, 5);
-  const rightColumn = POPULAR_SEARCHES.slice(5, 10);
+  const leftColumn = popularSearches.slice(0, 5);
+  const rightColumn = popularSearches.slice(5, 10);
 
   // 검색 모드일 때 UI
   if (isSearchMode) {
@@ -471,7 +482,7 @@ const styles = StyleSheet.create({
   },
   contentContainer: {
     paddingHorizontal: scale(24),
-    paddingBottom: verticalScale(40),
+    paddingBottom: verticalScale(100), // 하단 네비게이션 바 여유 공간
   },
   popularSearchSection: {
     marginTop: verticalScale(32),


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
기존에 카테고리 내에서 접근 가능했던 검색 화면과 별개로, 검색 탭 클릭 시 진입할 전용 검색 화면의 UI를 새로 구현하고 API를 연동했습니다
또한 기존 검색 화면과의 역할을 명확히 구분 짓기 위해 파일명을 `SearchScreen`->`CategorySearchScreen`으로 변경하였습니다


## 🔗 관련 이슈
close #33
<!-- 참고용: ref #이슈번호 -->

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [x] 새로운 기능
- [ ] 버그 수정
- [ ] UI/UX 개선
- [x] 리팩토링
- [ ] 의존성 변경

## 📸 스크린샷
### iOS
| 12시 인기 검색어 | 1시 인기 검색어 |
|---|---|
|<img width="300" height="1311" alt="IMG_6532" src="https://github.com/user-attachments/assets/2e56b3dd-1b64-4aab-939b-ec6ece84e9bc" />|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/13e06059-af99-4a96-b709-e4fcee74317e" />|

| 최근 검색어 | 검색 결과 O | 검색 결과 X |
|---|---|---|
|<img width="300" height="1311" alt="IMG_6536" src="https://github.com/user-attachments/assets/5940af94-84d0-4265-b715-109c9c800ecd" />|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/d32b1fbd-9360-40c3-8db8-b0a455e7bff0" />|<img width="300" height="1311" alt="IMG_6534" src="https://github.com/user-attachments/assets/577bf34b-32c6-47ab-bb79-067664ef47e3" />|

### Android
| 12시 인기 검색어 | 1시 인기 검색어 |
|---|---|
|<img width="300" height="2400" alt="image" src="https://github.com/user-attachments/assets/ab65c118-4769-4ce6-9ade-94a3241cab64" />|<img width="300" height="2400" alt="image" src="https://github.com/user-attachments/assets/fb6ed2bc-0f45-4c0f-ab65-3350cd1313fb" />|


| 최근 검색어 | 검색 결과 O | 검색 결과 X |
|---|---|---|
|<img width="295" height="2400" alt="image" src="https://github.com/user-attachments/assets/e13aac12-f3eb-41b0-beb9-e625e93dd21f" />|<img width="295" height="2400" alt="image" src="https://github.com/user-attachments/assets/52cd36ee-e2bf-4b71-b051-b2649fd34cfb" />|<img width="295" height="2400" alt="image" src="https://github.com/user-attachments/assets/3241ea22-5cd7-4510-8718-234c7a1ad711" />|



## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
- 인기 검색어의 경우 서버 기준 1시간 단위로 갱신됩니다.
- 처음에는 `SearchScreen`과 `CategorySearchScreen`의 최근 검색어를 각각 별도의 AsyncStorage 키로 구분하여 관리하였습니다.
그러나 1차 런칭 기준, 두 화면 모두 챌린지 검색만 지원하는 구조이기 때문에 검색어 특성상 동일한 최근 검색어를 공유하는 것이 더 적절하다고 판단하여 키를 통합했습니다.
- 추후 `SearchScreen`에 챌린저 검색 기능이 추가되면 기획 논의 후 필요에 따라 수정 예정입니다
- @sehwanii 현재 **검색** 타이틀이 포함된 헤더 부분은 컴포넌트화해서 작업 중이신 걸로 알고 있어서 일단은 제가 임시로 화면 내에 구현했습니다 추후 해당 컴포넌트가 develop 브랜치에 머지되고나면 컴포넌트 재사용하는 걸로 수정할 예정입니다~!

