### PR TITLE
[REFACTOR] 글 인증 게시물 이미지 다중 첨부 및 이미지 뷰어 추가

### DIFF
--- a/assets/icons/challenge-profile/delete-viewer.svg
+++ b/assets/icons/challenge-profile/delete-viewer.svg
@@ -1,0 +1,3 @@
+<svg width="9" height="9" viewBox="0 0 9 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.5 0.5L0.5 8.5M0.5 0.5L8.5 8.5" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/libs/api/challenge.ts
+++ b/src/libs/api/challenge.ts
@@ -665,6 +665,9 @@ export interface VerificationDetail {
   content: string;
   photoUrl: string;
   textUrl: string;
+  textImage1: string | null;
+  textImage2: string | null;
+  textImage3: string | null;
   isQuestion: boolean;
   status: string;
   createdAt: string;
@@ -713,7 +716,9 @@ export interface CreateTextVerificationRequest {
   title: string;
   content: string;
   textUrl: string;
-  photoUrl: string;
+  textImage1: string | null;
+  textImage2: string | null;
+  textImage3: string | null;
   isQuestion: boolean;
 }
 
@@ -789,7 +794,7 @@ export interface VerificationUser {
   userId: number;
   nickname: string;
   profileImageUrl: string;
-  role: string;
+  level: string;
 }
 
 /**
@@ -821,6 +826,9 @@ export interface VerificationDetailResponse {
     content: string;
     textUrl: string;
     photoUrl: string;
+    textImage1: string | null;
+    textImage2: string | null;
+    textImage3: string | null;
     isQuestion: boolean;
     isResolved: boolean;
     status: string;
@@ -1103,7 +1111,9 @@ export interface UpdateVerificationRequest {
   title?: string;
   content?: string;
   textUrl?: string;
-  photoUrl?: string;
+  textImage1?: string | null;
+  textImage2?: string | null;
+  textImage3?: string | null;
 }
 
 /**

--- a/src/libs/api/challenge.ts
+++ b/src/libs/api/challenge.ts
@@ -665,9 +665,7 @@ export interface VerificationDetail {
   content: string;
   photoUrl: string;
   textUrl: string;
-  textImage1: string | null;
-  textImage2: string | null;
-  textImage3: string | null;
+  textImages: string[];
   isQuestion: boolean;
   status: string;
   createdAt: string;
@@ -716,9 +714,7 @@ export interface CreateTextVerificationRequest {
   title: string;
   content: string;
   textUrl: string;
-  textImage1: string | null;
-  textImage2: string | null;
-  textImage3: string | null;
+  textImages: string[];
   isQuestion: boolean;
 }
 
@@ -826,9 +822,7 @@ export interface VerificationDetailResponse {
     content: string;
     textUrl: string;
     photoUrl: string;
-    textImage1: string | null;
-    textImage2: string | null;
-    textImage3: string | null;
+    textImages: string[];
     isQuestion: boolean;
     isResolved: boolean;
     status: string;
@@ -1111,9 +1105,8 @@ export interface UpdateVerificationRequest {
   title?: string;
   content?: string;
   textUrl?: string;
-  textImage1?: string | null;
-  textImage2?: string | null;
-  textImage3?: string | null;
+  textImages?: string[];
+  isQuestion?: boolean;
 }
 
 /**

--- a/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
@@ -101,15 +101,11 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
         size: 10,
       });
 
-      // textImage1~3 끝 슬래시 제거
-      if (result.textImage1 && result.textImage1.endsWith('/')) {
-        result.textImage1 = result.textImage1.slice(0, -1);
-      }
-      if (result.textImage2 && result.textImage2.endsWith('/')) {
-        result.textImage2 = result.textImage2.slice(0, -1);
-      }
-      if (result.textImage3 && result.textImage3.endsWith('/')) {
-        result.textImage3 = result.textImage3.slice(0, -1);
+      // textImages 배열 끝 슬래시 제거
+      if (result.textImages && Array.isArray(result.textImages)) {
+        result.textImages = result.textImages.map(url =>
+          url.endsWith('/') ? url.slice(0, -1) : url
+        );
       }
 
       setVerification(result);
@@ -587,11 +583,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
 
         {/* 이미지 */}
         {(() => {
-          const images = [
-            verification.textImage1,
-            verification.textImage2,
-            verification.textImage3,
-          ].filter(Boolean);
+          const images = verification.textImages || [];
 
           if (images.length === 0) return null;
 
@@ -974,11 +966,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
       >
         <ImageViewer
           imageUrls={(() => {
-            const images = [
-              verification?.textImage1,
-              verification?.textImage2,
-              verification?.textImage3,
-            ].filter(Boolean);
+            const images = verification?.textImages || [];
 
             return images.map(url => ({ url: url as string }));
           })()}

--- a/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
@@ -618,7 +618,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
 
         {/* 링크 */}
         {verification.textUrl && (
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.linkBox}
             onPress={() => {
               Linking.canOpenURL(verification.textUrl).then(supported => {
@@ -987,7 +987,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
           renderHeader={() => (
             <View style={styles.imageViewerHeader}>
               <LinearGradient
-                colors={['rgba(0, 0, 0, 0.5)', 'rgba(0, 0, 0, 0)']}
+                colors={['rgba(0, 0, 0, 0.2)', 'rgba(0, 0, 0, 0.1)', 'rgba(0, 0, 0, 0)']}
                 style={styles.imageViewerGradient}
               />
               <TouchableOpacity
@@ -1007,7 +1007,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
             return (
               <View style={styles.imageViewerFooter}>
                 <LinearGradient
-                  colors={['rgba(0, 0, 0, 0)', 'rgba(0, 0, 0, 0.5)']}
+                  colors={['rgba(0, 0, 0, 0)', 'rgba(0, 0, 0, 0.1)', 'rgba(0, 0, 0, 0.2)']}
                   style={StyleSheet.absoluteFill}
                 />
                 <View style={styles.imageViewerIndicator}>
@@ -1262,7 +1262,7 @@ const styles = StyleSheet.create({
     top: 0,
     left: 0,
     right: 0,
-    height: verticalScale(150),
+    height: verticalScale(100),
   },
   imageViewerCloseButton: {
     position: 'absolute',
@@ -1276,7 +1276,7 @@ const styles = StyleSheet.create({
   },
   imageViewerFooter: {
     width: Dimensions.get('window').width,
-    height: verticalScale(150),
+    height: verticalScale(100),
     justifyContent: 'flex-end',
     alignItems: 'center',
   },

--- a/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
@@ -101,9 +101,15 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
         size: 10,
       });
 
-      // photoUrl 끝 슬래시 제거
-      if (result.photoUrl && result.photoUrl.endsWith('/')) {
-        result.photoUrl = result.photoUrl.slice(0, -1);
+      // textImage1~3 끝 슬래시 제거
+      if (result.textImage1 && result.textImage1.endsWith('/')) {
+        result.textImage1 = result.textImage1.slice(0, -1);
+      }
+      if (result.textImage2 && result.textImage2.endsWith('/')) {
+        result.textImage2 = result.textImage2.slice(0, -1);
+      }
+      if (result.textImage3 && result.textImage3.endsWith('/')) {
+        result.textImage3 = result.textImage3.slice(0, -1);
       }
 
       setVerification(result);
@@ -547,7 +553,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
               </Text>
               <View style={styles.dot} />
               <Text variant="smReg" color={colors.text.tertiary}>
-                {getUserRoleText(verification.user.role)}
+                {getUserRoleText(verification.user.level)}
               </Text>
             </View>
             <View style={styles.timeSpacing} />
@@ -580,23 +586,36 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
         </Text>
 
         {/* 이미지 */}
-        {verification.photoUrl && (
-          <TouchableOpacity
-            activeOpacity={0.9}
-            onPress={() => setIsImageViewerVisible(true)}
-            style={styles.imageContainer}
-          >
-            <Image
-              source={{ uri: verification.photoUrl }}
-              style={styles.image}
-              resizeMode="cover"
-              onLoad={() => {
-              }}
-              onError={(error) => {
-              }}
-            />
-          </TouchableOpacity>
-        )}
+        {(() => {
+          const images = [
+            verification.textImage1,
+            verification.textImage2,
+            verification.textImage3,
+          ].filter(Boolean);
+
+          if (images.length === 0) return null;
+
+          return (
+            <View style={styles.imagesContainer}>
+              {images.map((imageUrl, index) => (
+                <TouchableOpacity
+                  key={index}
+                  activeOpacity={0.9}
+                  onPress={() => setIsImageViewerVisible(true)}
+                  style={styles.imageContainer}
+                >
+                  <Image
+                    source={{ uri: imageUrl as string }}
+                    style={styles.image}
+                    resizeMode="cover"
+                    onLoad={() => { }}
+                    onError={(error) => { }}
+                  />
+                </TouchableOpacity>
+              ))}
+            </View>
+          );
+        })()}
 
         {/* 링크 */}
         {verification.textUrl && (
@@ -954,7 +973,15 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
         onRequestClose={() => setIsImageViewerVisible(false)}
       >
         <ImageViewer
-          imageUrls={[{ url: verification?.photoUrl || '' }]}
+          imageUrls={(() => {
+            const images = [
+              verification?.textImage1,
+              verification?.textImage2,
+              verification?.textImage3,
+            ].filter(Boolean);
+
+            return images.map(url => ({ url: url as string }));
+          })()}
           enableSwipeDown
           onSwipeDown={() => setIsImageViewerVisible(false)}
           onClick={() => setIsImageViewerVisible(false)}
@@ -1049,6 +1076,9 @@ const styles = StyleSheet.create({
   },
   linkText: {
     flex: 1,
+  },
+  imagesContainer: {
+    gap: verticalScale(8),
   },
   imageContainer: {
     width: '100%',

--- a/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
@@ -84,6 +84,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
 
   // 이미지 뷰어 관련 state
   const [isImageViewerVisible, setIsImageViewerVisible] = useState(false);
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0);
 
   const fetchVerificationDetail = useCallback(async () => {
     try {
@@ -593,7 +594,10 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
                 <TouchableOpacity
                   key={index}
                   activeOpacity={0.9}
-                  onPress={() => setIsImageViewerVisible(true)}
+                  onPress={() => {
+                    setSelectedImageIndex(index);
+                    setIsImageViewerVisible(true);
+                  }}
                   style={styles.imageContainer}
                 >
                   <Image
@@ -970,6 +974,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
 
             return images.map(url => ({ url: url as string }));
           })()}
+          index={selectedImageIndex}
           enableSwipeDown
           onSwipeDown={() => setIsImageViewerVisible(false)}
           onClick={() => setIsImageViewerVisible(false)}

--- a/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
@@ -86,6 +86,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
   // 이미지 뷰어 관련 state
   const [isImageViewerVisible, setIsImageViewerVisible] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+  const [currentImageIndex, setCurrentImageIndex] = useState(0);
 
   const fetchVerificationDetail = useCallback(async () => {
     try {
@@ -597,6 +598,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
                   activeOpacity={0.9}
                   onPress={() => {
                     setSelectedImageIndex(index);
+                    setCurrentImageIndex(index);
                     setIsImageViewerVisible(true);
                   }}
                   style={styles.imageContainer}
@@ -981,6 +983,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
           backgroundColor="rgba(0, 0, 0, 1)"
           renderIndicator={() => <View />}
           saveToLocalByLongPress={false}
+          onChange={(index) => setCurrentImageIndex(index || 0)}
           renderHeader={() => (
             <View style={styles.imageViewerHeader}>
               <LinearGradient
@@ -997,6 +1000,30 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
               </TouchableOpacity>
             </View>
           )}
+          renderFooter={() => {
+            const totalImages = verification?.textImages?.length || 0;
+            if (totalImages <= 1) return <View />;
+
+            return (
+              <View style={styles.imageViewerFooter}>
+                <LinearGradient
+                  colors={['rgba(0, 0, 0, 0)', 'rgba(0, 0, 0, 0.5)']}
+                  style={StyleSheet.absoluteFill}
+                />
+                <View style={styles.imageViewerIndicator}>
+                  {Array.from({ length: totalImages }).map((_, index) => (
+                    <View
+                      key={index}
+                      style={[
+                        styles.indicatorDot,
+                        currentImageIndex === index ? styles.indicatorDotActive : styles.indicatorDotInactive
+                      ]}
+                    />
+                  ))}
+                </View>
+              </View>
+            );
+          }}
         />
       </Modal>
     </SafeAreaView>
@@ -1246,5 +1273,30 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     zIndex: 1001,
+  },
+  imageViewerFooter: {
+    width: Dimensions.get('window').width,
+    height: verticalScale(150),
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  imageViewerIndicator: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: Platform.OS === 'ios' ? verticalScale(50) : verticalScale(30),
+    zIndex: 1001,
+  },
+  indicatorDot: {
+    width: scale(6),
+    height: scale(6),
+    borderRadius: scale(3),
+    marginHorizontal: scale(4),
+  },
+  indicatorDotActive: {
+    backgroundColor: colors.white,
+  },
+  indicatorDotInactive: {
+    backgroundColor: 'rgba(255, 255, 255, 0.4)',
   },
 });

--- a/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
@@ -5,6 +5,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp, useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import ImageViewer from 'react-native-image-zoom-viewer';
+import LinearGradient from 'react-native-linear-gradient';
 import { Header } from '../../components/common/Header';
 import { Button } from '../../components/common/Button';
 import { Text } from '../../components/common/Text';
@@ -39,7 +40,7 @@ import LockIcon from '../../../assets/icons/lock.svg';
 import UnlockIcon from '../../../assets/icons/unlock.svg';
 import SendIcon from '../../../assets/icons/send.svg';
 import ChevronDownIcon from '../../../assets/icons/chevron-down-text-primary.svg';
-
+import DeleteViewerIcon from '../../../assets/icons/challenge-profile/delete-viewer.svg';
 type ChallengeCertificationDetailScreenRouteProp = RouteProp<RootStackParamList, 'ChallengeCertificationDetail'>;
 type ChallengeCertificationDetailScreenNavigationProp = StackNavigationProp<
   RootStackParamList,
@@ -977,10 +978,25 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
           index={selectedImageIndex}
           enableSwipeDown
           onSwipeDown={() => setIsImageViewerVisible(false)}
-          onClick={() => setIsImageViewerVisible(false)}
           backgroundColor="rgba(0, 0, 0, 1)"
           renderIndicator={() => <View />}
           saveToLocalByLongPress={false}
+          renderHeader={() => (
+            <View style={styles.imageViewerHeader}>
+              <LinearGradient
+                colors={['rgba(0, 0, 0, 0.5)', 'rgba(0, 0, 0, 0)']}
+                style={styles.imageViewerGradient}
+              />
+              <TouchableOpacity
+                onPress={() => setIsImageViewerVisible(false)}
+                activeOpacity={0.7}
+                style={styles.imageViewerCloseButton}
+                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+              >
+                <DeleteViewerIcon width={20} height={20} />
+              </TouchableOpacity>
+            </View>
+          )}
         />
       </Modal>
     </SafeAreaView>
@@ -1206,5 +1222,29 @@ const styles = StyleSheet.create({
     paddingHorizontal: scale(24),
     paddingTop: verticalScale(12),
     alignItems: 'center',
+  },
+  imageViewerHeader: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 1000,
+  },
+  imageViewerGradient: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: verticalScale(150),
+  },
+  imageViewerCloseButton: {
+    position: 'absolute',
+    top: Platform.OS === 'ios' ? verticalScale(50) : verticalScale(20),
+    left: scale(20),
+    width: scale(44),
+    height: verticalScale(44),
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 1001,
   },
 });

--- a/src/screens/ChallengeProfile/ChallengeCertificationTextEditScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationTextEditScreen.tsx
@@ -54,18 +54,32 @@ export const ChallengeCertificationTextEditScreen: React.FC = () => {
 
   // 기존 이미지 초기화
   useEffect(() => {
-    if (verification.photoUrl) {
-      const cleanUrl = verification.photoUrl.endsWith('/')
-        ? verification.photoUrl.slice(0, -1)
-        : verification.photoUrl;
+    const images: Array<{ uri: string; url: string; uploading: boolean }> = [];
 
-      setSelectedImages([{
-        uri: cleanUrl,
-        url: cleanUrl,
-        uploading: false,
-      }]);
+    // textImage1, textImage2, textImage3 순서로 이미지 추가
+    if (verification.textImage1) {
+      const cleanUrl = verification.textImage1.endsWith('/')
+        ? verification.textImage1.slice(0, -1)
+        : verification.textImage1;
+      images.push({ uri: cleanUrl, url: cleanUrl, uploading: false });
     }
-  }, [verification.photoUrl]);
+
+    if (verification.textImage2) {
+      const cleanUrl = verification.textImage2.endsWith('/')
+        ? verification.textImage2.slice(0, -1)
+        : verification.textImage2;
+      images.push({ uri: cleanUrl, url: cleanUrl, uploading: false });
+    }
+
+    if (verification.textImage3) {
+      const cleanUrl = verification.textImage3.endsWith('/')
+        ? verification.textImage3.slice(0, -1)
+        : verification.textImage3;
+      images.push({ uri: cleanUrl, url: cleanUrl, uploading: false });
+    }
+
+    setSelectedImages(images);
+  }, [verification.textImage1, verification.textImage2, verification.textImage3]);
 
   // 기존 링크 초기화
   useEffect(() => {
@@ -183,7 +197,17 @@ export const ChallengeCertificationTextEditScreen: React.FC = () => {
 
   const handleGalleryPress = async () => {
     try {
-      const assets = await openGalleryMultiple(10);
+      // 이미 선택된 이미지 개수 확인
+      const currentImageCount = selectedImages.length;
+      
+      if (currentImageCount >= 3) {
+        Alert.alert('알림', '이미지는 최대 3장까지 첨부 가능합니다.');
+        return;
+      }
+
+      // 남은 개수만큼만 선택 가능
+      const remainingCount = 3 - currentImageCount;
+      const assets = await openGalleryMultiple(remainingCount);
 
       if (assets && assets.length > 0) {
         // 선택한 이미지들을 state에 추가 (uploading 상태로)
@@ -318,16 +342,18 @@ export const ChallengeCertificationTextEditScreen: React.FC = () => {
     try {
       setIsSubmitting(true);
 
-      // 첫 번째 이미지 URL 사용
-      const photoUrl = selectedImages.length > 0 && selectedImages[0].url
-        ? selectedImages[0].url
-        : '';
+      // 최대 3개까지 이미지 URL 추출
+      const textImage1 = selectedImages.length > 0 && selectedImages[0].url ? selectedImages[0].url : null;
+      const textImage2 = selectedImages.length > 1 && selectedImages[1].url ? selectedImages[1].url : null;
+      const textImage3 = selectedImages.length > 2 && selectedImages[2].url ? selectedImages[2].url : null;
 
       await updateVerification(verification.verificationId, {
         title: title.trim(),
         content: content.trim(),
         textUrl: attachedLink || '',
-        photoUrl: photoUrl,
+        textImage1,
+        textImage2,
+        textImage3,
       });
 
       Alert.alert('성공', '게시글이 수정되었습니다.', [

--- a/src/screens/ChallengeProfile/ChallengeCertificationTextEditScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationTextEditScreen.tsx
@@ -56,30 +56,20 @@ export const ChallengeCertificationTextEditScreen: React.FC = () => {
   useEffect(() => {
     const images: Array<{ uri: string; url: string; uploading: boolean }> = [];
 
-    // textImage1, textImage2, textImage3 순서로 이미지 추가
-    if (verification.textImage1) {
-      const cleanUrl = verification.textImage1.endsWith('/')
-        ? verification.textImage1.slice(0, -1)
-        : verification.textImage1;
-      images.push({ uri: cleanUrl, url: cleanUrl, uploading: false });
-    }
-
-    if (verification.textImage2) {
-      const cleanUrl = verification.textImage2.endsWith('/')
-        ? verification.textImage2.slice(0, -1)
-        : verification.textImage2;
-      images.push({ uri: cleanUrl, url: cleanUrl, uploading: false });
-    }
-
-    if (verification.textImage3) {
-      const cleanUrl = verification.textImage3.endsWith('/')
-        ? verification.textImage3.slice(0, -1)
-        : verification.textImage3;
-      images.push({ uri: cleanUrl, url: cleanUrl, uploading: false });
+    // textImages 배열에서 이미지 추가
+    if (verification.textImages && Array.isArray(verification.textImages)) {
+      verification.textImages.forEach((imageUrl) => {
+        if (imageUrl) {
+          const cleanUrl = imageUrl.endsWith('/')
+            ? imageUrl.slice(0, -1)
+            : imageUrl;
+          images.push({ uri: cleanUrl, url: cleanUrl, uploading: false });
+        }
+      });
     }
 
     setSelectedImages(images);
-  }, [verification.textImage1, verification.textImage2, verification.textImage3]);
+  }, [verification.textImages]);
 
   // 기존 링크 초기화
   useEffect(() => {
@@ -199,7 +189,7 @@ export const ChallengeCertificationTextEditScreen: React.FC = () => {
     try {
       // 이미 선택된 이미지 개수 확인
       const currentImageCount = selectedImages.length;
-      
+
       if (currentImageCount >= 3) {
         Alert.alert('알림', '이미지는 최대 3장까지 첨부 가능합니다.');
         return;
@@ -342,18 +332,16 @@ export const ChallengeCertificationTextEditScreen: React.FC = () => {
     try {
       setIsSubmitting(true);
 
-      // 최대 3개까지 이미지 URL 추출
-      const textImage1 = selectedImages.length > 0 && selectedImages[0].url ? selectedImages[0].url : null;
-      const textImage2 = selectedImages.length > 1 && selectedImages[1].url ? selectedImages[1].url : null;
-      const textImage3 = selectedImages.length > 2 && selectedImages[2].url ? selectedImages[2].url : null;
+      // 이미지 URL 배열 추출
+      const textImages = selectedImages
+        .filter(img => img.url)
+        .map(img => img.url);
 
       await updateVerification(verification.verificationId, {
         title: title.trim(),
         content: content.trim(),
         textUrl: attachedLink || '',
-        textImage1,
-        textImage2,
-        textImage3,
+        textImages: textImages,
       });
 
       Alert.alert('성공', '게시글이 수정되었습니다.', [

--- a/src/screens/ChallengeProfile/ChallengeCertificationTextScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationTextScreen.tsx
@@ -308,18 +308,16 @@ export const ChallengeCertificationTextScreen: React.FC = () => {
     try {
       setIsSubmitting(true);
 
-      // 최대 3개까지 이미지 URL 추출
-      const textImage1 = selectedImages.length > 0 && selectedImages[0].url ? selectedImages[0].url : null;
-      const textImage2 = selectedImages.length > 1 && selectedImages[1].url ? selectedImages[1].url : null;
-      const textImage3 = selectedImages.length > 2 && selectedImages[2].url ? selectedImages[2].url : null;
+      // 이미지 URL 배열 추출
+      const textImages = selectedImages
+        .filter(img => img.url)
+        .map(img => img.url);
 
       const result = await createTextVerification(challengeId, {
         title: title.trim(),
         content: content.trim(),
         textUrl: attachedLink || '',
-        textImage1,
-        textImage2,
-        textImage3,
+        textImages: textImages,
         isQuestion: isQuestionEnabled,
       });
 

--- a/src/screens/ChallengeProfile/ChallengeCertificationTextScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationTextScreen.tsx
@@ -164,7 +164,17 @@ export const ChallengeCertificationTextScreen: React.FC = () => {
 
   const handleGalleryPress = async () => {
     try {
-      const assets = await openGalleryMultiple(10);
+      // 이미 선택된 이미지 개수 확인
+      const currentImageCount = selectedImages.length;
+
+      if (currentImageCount >= 3) {
+        Alert.alert('알림', '이미지는 최대 3장까지 첨부 가능합니다.');
+        return;
+      }
+
+      // 남은 개수만큼만 선택 가능
+      const remainingCount = 3 - currentImageCount;
+      const assets = await openGalleryMultiple(remainingCount);
 
       if (assets && assets.length > 0) {
         // 선택한 이미지들을 state에 추가 (uploading 상태로)
@@ -298,16 +308,18 @@ export const ChallengeCertificationTextScreen: React.FC = () => {
     try {
       setIsSubmitting(true);
 
-      // 첫 번째 업로드된 이미지의 전체 URL 사용
-      const photoUrl = selectedImages.length > 0 && selectedImages[0].url
-        ? selectedImages[0].url
-        : '';
+      // 최대 3개까지 이미지 URL 추출
+      const textImage1 = selectedImages.length > 0 && selectedImages[0].url ? selectedImages[0].url : null;
+      const textImage2 = selectedImages.length > 1 && selectedImages[1].url ? selectedImages[1].url : null;
+      const textImage3 = selectedImages.length > 2 && selectedImages[2].url ? selectedImages[2].url : null;
 
       const result = await createTextVerification(challengeId, {
         title: title.trim(),
         content: content.trim(),
         textUrl: attachedLink || '',
-        photoUrl: photoUrl,
+        textImage1,
+        textImage2,
+        textImage3,
         isQuestion: isQuestionEnabled,
       });
 


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
- 글 인증 게시글 작성 시 사진 첨부가 기존 1장 -> **최대 3장**까지 가능하도록 변경됨에 따라 이미지 처리 구조를 수정하였습니다
- 게시글 상세 화면에서 이미지를 클릭하면 전체 화면으로 확인할 수 있는 이미지 뷰어 기능을 추가했습니다
- 이미지 뷰어는 사용성을 고려하여 상단에는 닫기 버튼, 하단에는 인디케이터를 제공합니다


## 🔗 관련 이슈
close #36 
<!-- 참고용: ref #이슈번호 -->

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [x] 새로운 기능
- [ ] 버그 수정
- [x] UI/UX 개선
- [x] 리팩토링
- [ ] 의존성 변경

## 📸 스크린샷
### iOS
| 게시글 작성 시 | 게시글 수정 시 |
|---|---|
|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/04856203-d294-4454-830d-8f648b593238" />|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/bf24f5c6-d44b-4fdd-b2f6-fd328b78d72c" />|

| 게시글 상세 화면 | 이미지 뷰어 | 상·하단 그라데이션 |
|---|---|---|
|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/6f05b3f8-c4a7-4b1d-984c-6a1426e214bc" />|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/b7288667-6d4a-48f2-9db6-bef861cdc757" />|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/8a55b0ec-2082-416d-8426-d2d600099b40" />|


## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
- 이미지 뷰어는 UX 개선을 목적으로 추가되었으며, 당근 어플의 인터랙션을 참고하여 구현하였습니다. 추후 논의에 따라 변경될 수 있습니다