### PR TITLE
[FEAT] 알림 목록 UI 구현 및 알림 플로우 API 연동

### DIFF
--- a/src/components/challenge/CommentItem.tsx
+++ b/src/components/challenge/CommentItem.tsx
@@ -303,7 +303,6 @@ const styles = StyleSheet.create({
   },
   commentText: {
     marginBottom: verticalScale(12),
-    lineHeight: verticalScale(18),
   },
   actionsRow: {
     flexDirection: 'row',

--- a/src/components/home/ChallengeCarousel.tsx
+++ b/src/components/home/ChallengeCarousel.tsx
@@ -170,7 +170,6 @@ const styles = StyleSheet.create({
     color: colors.text.tertiary,
     textAlign: 'center',
     marginTop: verticalScale(20),
-    lineHeight: verticalScale(18),
   },
   itemContainer: {
     width: ITEM_SIZE,

--- a/src/components/home/TopAppBar.tsx
+++ b/src/components/home/TopAppBar.tsx
@@ -1,17 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, TouchableOpacity, StyleSheet, Platform } from 'react-native';
 import { scale, verticalScale } from '../../utils/scaling';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { RootStackParamList } from '../../navigation/types';
 import { colors } from '../../design/tokens';
+import { getUnreadStatus } from '../../libs/api/notification';
 import Logo from '../../../assets/images/logo-primary.svg';
 import BellIcon from '../../../assets/icons/alarm.svg';
 
 const TopAppBar = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   const insets = useSafeAreaInsets();
+  const [hasUnread, setHasUnread] = useState(false);
 
   // Android: 펀치홀/상태바 간섭을 피하기 위해 더 넉넉한 패딩 (24)
   // iOS: 기존 디자인 스펙 유지 (16)
@@ -19,13 +21,30 @@ const TopAppBar = () => {
 
   // safeAreaTop 높이 계산
   const safeAreaTop = Platform.OS === 'android'
-    ? Math.max(insets.top, 24) 
+    ? Math.max(insets.top, 24)
     : insets.top;
+
+  // 읽지 않은 알림 상태 조회
+  const fetchUnreadStatus = async () => {
+    try {
+      const unread = await getUnreadStatus();
+      setHasUnread(unread);
+    } catch (error) {
+      // 에러가 나도 화면은 정상 동작하도록 함
+    }
+  };
+
+  // 홈 화면에 포커스될 때마다 읽지 않은 알림 상태 확인
+  useFocusEffect(
+    React.useCallback(() => {
+      fetchUnreadStatus();
+    }, [])
+  );
 
   return (
     <View style={[
-      styles.container, 
-      { 
+      styles.container,
+      {
         paddingTop: safeAreaTop + verticalPadding,
         paddingBottom: verticalPadding - 4 // borderBottomWidth 1px + 콘텐츠 높이 차이 3px 차감
       }
@@ -47,6 +66,7 @@ const TopAppBar = () => {
           style={styles.iconWrapper}
         >
           <BellIcon width={18.82} height={20} />
+          {hasUnread && <View style={styles.badge} />}
         </TouchableOpacity>
       </View>
     </View>
@@ -76,6 +96,16 @@ const styles = StyleSheet.create({
     height: verticalScale(24),
     justifyContent: 'center',
     alignItems: 'center',
+    position: 'relative',
+  },
+  badge: {
+    position: 'absolute',
+    top: 0,
+    right: scale(-0.5),
+    width: scale(6),
+    height: scale(6),
+    borderRadius: scale(10),
+    backgroundColor: colors.primary.main,
   },
 });
 

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -11,6 +11,7 @@ interface NotificationItemProps {
   description: string;
   timeAgo: string;
   isRead: boolean;
+  showButtons?: boolean; // 버튼 표시 여부 (기본값: true)
   onPress?: () => void;
   onYesPress?: () => void;
   onNoPress?: () => void;
@@ -23,6 +24,7 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
   timeAgo,
   type,
   isRead,
+  showButtons = true,
   onPress,
   onYesPress,
   onNoPress,
@@ -50,7 +52,7 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
           {description}
         </Text>
 
-        {type === 'challenge_ending' && (
+        {type === 'challenge_ending' && showButtons && (
           <View style={styles.buttonContainer}>
             <TouchableOpacity style={styles.yesButton} onPress={onYesPress}>
               <Text variant="xsReg" color={colors.white} style={styles.yesButtonText}>

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { View, StyleSheet, TouchableOpacity, Image } from 'react-native';
+import { scale, verticalScale } from '../../utils/scaling';
+import { colors } from '../../design/tokens';
+import { Text } from '../common/Text';
+
+interface NotificationItemProps {
+  type: 'normal' | 'challenge_ending';
+  profileImage: number;
+  title: string;
+  description: string;
+  timeAgo: string;
+  isRead: boolean;
+  onYesPress?: () => void;
+  onNoPress?: () => void;
+}
+
+export const NotificationItem: React.FC<NotificationItemProps> = ({
+  profileImage,
+  title,
+  description,
+  timeAgo,
+  type,
+  isRead,
+  onYesPress,
+  onNoPress,
+}) => {
+  return (
+    <View style={[
+      styles.notificationItem,
+      !isRead && styles.notificationItemUnread,
+    ]}>
+      <Image source={profileImage} style={styles.profileImage} />
+      <View style={styles.notificationContent}>
+        <View style={styles.notificationHeader}>
+          <Text variant="smMd" color={colors.text.primary} style={styles.notificationTitle}>
+            {title}
+          </Text>
+          <Text variant="caption" color={colors.text.tertiary}>
+            {timeAgo}
+          </Text>
+        </View>
+        <Text variant="xsReg" color={colors.text.primary} style={styles.notificationDescription}>
+          {description}
+        </Text>
+
+        {type === 'challenge_ending' && (
+          <View style={styles.buttonContainer}>
+            <TouchableOpacity style={styles.yesButton} onPress={onYesPress}>
+              <Text variant="xsReg" color={colors.white} style={styles.yesButtonText}>
+                네
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.noButton} onPress={onNoPress}>
+              <Text variant="xsReg" color={colors.text.primary} style={styles.noButtonText}>
+                아니오
+              </Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  notificationItem: {
+    flexDirection: 'row',
+    paddingHorizontal: scale(20),
+    paddingVertical: verticalScale(16),
+    backgroundColor: colors.white,
+  },
+  notificationItemUnread: {
+    backgroundColor: colors.primary.lightest,
+  },
+  profileImage: {
+    width: scale(40),
+    height: scale(40),
+    borderRadius: scale(20),
+    marginRight: scale(14),
+  },
+  notificationContent: {
+    flex: 1,
+  },
+  notificationHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+  },
+  notificationTitle: {
+    flex: 1,
+    marginRight: scale(8),
+  },
+  notificationDescription: {
+    lineHeight: verticalScale(18),
+    marginTop: verticalScale(4),
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    marginTop: verticalScale(16),
+    gap: scale(8),
+  },
+  yesButton: {
+    paddingHorizontal: scale(20),
+    paddingVertical: verticalScale(4),
+    borderRadius: scale(20),
+    backgroundColor: colors.primary.main,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: scale(52),
+    minHeight: verticalScale(26),
+  },
+  yesButtonText: {
+    lineHeight: verticalScale(18),
+  },
+  noButton: {
+    paddingHorizontal: scale(18),
+    paddingVertical: verticalScale(4),
+    borderRadius: scale(20),
+    backgroundColor: colors.background,
+    borderWidth: scale(1),
+    borderColor: colors.line,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: scale(74),
+    minHeight: verticalScale(26),
+  },
+  noButtonText: {
+    lineHeight: verticalScale(18),
+  },
+});
+

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -98,7 +98,6 @@ const styles = StyleSheet.create({
     marginRight: scale(8),
   },
   notificationDescription: {
-    lineHeight: verticalScale(18),
     marginTop: verticalScale(4),
   },
   buttonContainer: {
@@ -116,9 +115,7 @@ const styles = StyleSheet.create({
     minWidth: scale(52),
     minHeight: verticalScale(26),
   },
-  yesButtonText: {
-    lineHeight: verticalScale(18),
-  },
+  yesButtonText: {},
   noButton: {
     paddingHorizontal: scale(18),
     paddingVertical: verticalScale(4),
@@ -131,8 +128,6 @@ const styles = StyleSheet.create({
     minWidth: scale(74),
     minHeight: verticalScale(26),
   },
-  noButtonText: {
-    lineHeight: verticalScale(18),
-  },
+  noButtonText: {},
 });
 

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -11,6 +11,7 @@ interface NotificationItemProps {
   description: string;
   timeAgo: string;
   isRead: boolean;
+  onPress?: () => void;
   onYesPress?: () => void;
   onNoPress?: () => void;
 }
@@ -22,14 +23,19 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
   timeAgo,
   type,
   isRead,
+  onPress,
   onYesPress,
   onNoPress,
 }) => {
   return (
-    <View style={[
-      styles.notificationItem,
-      !isRead && styles.notificationItemUnread,
-    ]}>
+    <TouchableOpacity
+      style={[
+        styles.notificationItem,
+        !isRead && styles.notificationItemUnread,
+      ]}
+      onPress={onPress}
+      activeOpacity={0.7}
+    >
       <Image source={profileImage} style={styles.profileImage} />
       <View style={styles.notificationContent}>
         <View style={styles.notificationHeader}>
@@ -59,7 +65,7 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
           </View>
         )}
       </View>
-    </View>
+    </TouchableOpacity>
   );
 };
 

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { View, StyleSheet, TouchableOpacity, Image } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, Image, ImageSourcePropType } from 'react-native';
 import { scale, verticalScale } from '../../utils/scaling';
 import { colors } from '../../design/tokens';
 import { Text } from '../common/Text';
 
 interface NotificationItemProps {
   type: 'normal' | 'challenge_ending';
-  profileImage: number;
+  profileImage: ImageSourcePropType;
   title: string;
   description: string;
   timeAgo: string;

--- a/src/design/tokens.ts
+++ b/src/design/tokens.ts
@@ -31,6 +31,7 @@ export const typography = {
     fontWeight: '600' as const,
     fontFamily: 'Pretendard-SemiBold',
     letterSpacing: -0.3,
+    lineHeight: moderateScale(34),
   },
   // hrr/Header 2
   header2: {
@@ -38,6 +39,7 @@ export const typography = {
     fontWeight: '600' as const,
     fontFamily: 'Pretendard-SemiBold',
     letterSpacing: -0.3,
+    lineHeight: moderateScale(28),
   },
   // hrr/Header 3
   header3: {
@@ -45,6 +47,7 @@ export const typography = {
     fontWeight: '600' as const,
     fontFamily: 'Pretendard-SemiBold',
     letterSpacing: -0.3,
+    lineHeight: moderateScale(26),
   },
   // hrr/Header 4
   header4: {
@@ -52,6 +55,7 @@ export const typography = {
     fontWeight: '600' as const,
     fontFamily: 'Pretendard-SemiBold',
     letterSpacing: -0.3,
+    lineHeight: moderateScale(22),
   },
   // hrr/Md size
   md: {
@@ -67,6 +71,7 @@ export const typography = {
     fontWeight: '500' as const,
     fontFamily: 'Pretendard-Medium',
     letterSpacing: -0.3,
+    lineHeight: moderateScale(21),
   },
   // hrr/Sm size (Reg)
   smReg: {
@@ -74,6 +79,7 @@ export const typography = {
     fontWeight: '400' as const,
     fontFamily: 'Pretendard-Regular',
     letterSpacing: -0.3,
+    lineHeight: moderateScale(21),
   },
   // hrr/Xs size (Md)
   xsMd: {
@@ -81,6 +87,7 @@ export const typography = {
     fontWeight: '500' as const,
     fontFamily: 'Pretendard-Medium',
     letterSpacing: -0.3,
+    lineHeight: moderateScale(18),
   },
   // hrr/Xs size (Reg)
   xsReg: {
@@ -88,6 +95,7 @@ export const typography = {
     fontWeight: '400' as const,
     fontFamily: 'Pretendard-Regular',
     letterSpacing: -0.3,
+    lineHeight: moderateScale(18),
   },
   // hrr/Xxs size
   xxs: {
@@ -95,6 +103,7 @@ export const typography = {
     fontWeight: '400' as const,
     fontFamily: 'Pretendard-Regular',
     letterSpacing: -0.3,
+    lineHeight: moderateScale(17),
   },
   // hrr/caption
   caption: {
@@ -102,6 +111,7 @@ export const typography = {
     fontWeight: '400' as const,
     fontFamily: 'Pretendard-Regular',
     letterSpacing: -0.3,
+    lineHeight: moderateScale(14),
   },
 } as const;
 

--- a/src/libs/api/challenge.ts
+++ b/src/libs/api/challenge.ts
@@ -913,6 +913,50 @@ export const getChallengeRounds = async (challengeId: number): Promise<RoundItem
 };
 
 /**
+ * 챌린지 연장 여부 결정 타입
+ */
+export type RoundDecisionIntent = 'CONTINUE' | 'STOP';
+
+/**
+ * 챌린지 연장 여부 결정 요청
+ */
+export interface RoundDecisionRequest {
+  intent: RoundDecisionIntent;
+}
+
+/**
+ * 챌린지 연장 여부 결정 응답
+ */
+export interface RoundDecisionResponse {
+  isSuccess: boolean;
+  status: string;
+  code: string;
+  message: string;
+  result: null;
+}
+
+/**
+ * 챌린지 연장 여부 결정
+ */
+export const submitRoundDecision = async (
+  challengeId: number,
+  intent: RoundDecisionIntent
+): Promise<void> => {
+  try {
+    const response = await apiClient.post<RoundDecisionResponse>(
+      `/api/v1/challenges/${challengeId}/rounds/decision`,
+      { intent }
+    );
+
+    if (!response.data.isSuccess) {
+      throw new Error(response.data.message || '챌린지 연장 여부 제출에 실패했습니다.');
+    }
+  } catch (error: any) {
+    throw error;
+  }
+};
+
+/**
  * 인증 통계 정보
  */
 export interface VerificationStat {

--- a/src/libs/api/notification.ts
+++ b/src/libs/api/notification.ts
@@ -111,3 +111,36 @@ export const markNotificationAsRead = async (
   }
 };
 
+/**
+ * 읽지 않은 알림 상태 조회 응답
+ */
+export interface GetUnreadStatusResponse {
+  isSuccess: boolean;
+  status: string;
+  code: string;
+  message: string;
+  result: {
+    hasUnread: boolean;
+  };
+}
+
+/**
+ * 읽지 않은 알림 상태 조회
+ */
+export const getUnreadStatus = async (): Promise<boolean> => {
+  try {
+    const response = await apiClient.get<GetUnreadStatusResponse>(
+      '/api/v1/notifications/unread-status'
+    );
+
+    if (response.data.isSuccess && response.data.result) {
+      return response.data.result.hasUnread;
+    }
+
+    return false;
+  } catch (error: any) {
+    // 에러가 발생해도 조용히 false 반환
+    return false;
+  }
+};
+

--- a/src/libs/api/notification.ts
+++ b/src/libs/api/notification.ts
@@ -1,0 +1,78 @@
+import { apiClient } from './client';
+
+/**
+ * ============================================
+ * 알림 관련
+ * ============================================
+ */
+
+/**
+ * 알림 아이템
+ */
+export interface NotificationItem {
+  id: number;
+  title: string;
+  message: string;
+  imageUrl: string;
+  category: 'CHALLENGE' | 'VERIFICATION' | 'FOLLOW' | 'BADGE';
+  type: 'CHALLENGE_EXTENSION' | string; // 현재는 CHALLENGE_EXTENSION만 존재, 추후 추가 예정
+  targetType: 'CHALLENGE' | 'VERIFICATION' | 'COMMENT' | 'USER' | 'BADGE' | 'ROUND'; // 화면 이동을 위한 타입
+  targetId: number;
+  contextType: 'CHALLENGE' | 'VERIFICATION' | 'COMMENT' | 'USER' | 'BADGE' | 'ROUND'; // 추가 처리를 위한 타입
+  contextId: number;
+  isRead: boolean;
+  createdAt: string;
+}
+
+/**
+ * 알림 목록 조회 요청 파라미터
+ */
+export interface GetNotificationsParams {
+  category?: 'CHALLENGE' | 'VERIFICATION' | 'FOLLOW' | 'BADGE';
+  page?: number;
+  size?: number;
+}
+
+/**
+ * 알림 목록 조회 응답
+ */
+export interface GetNotificationsResponse {
+  isSuccess: boolean;
+  status: string;
+  code: string;
+  message: string;
+  result: {
+    content: NotificationItem[];
+    currentPage: number;
+    size: number;
+    hasNext: boolean;
+    first: boolean;
+    last: boolean;
+  };
+}
+
+/**
+ * 알림 목록 조회
+ */
+export const getNotifications = async (
+  params?: GetNotificationsParams
+): Promise<GetNotificationsResponse['result']> => {
+  try {
+    const response = await apiClient.get<GetNotificationsResponse>('/api/v1/notifications', {
+      params: {
+        category: params?.category,
+        page: params?.page ?? 1,
+        size: params?.size ?? 10,
+      },
+    });
+
+    if (response.data.isSuccess && response.data.result) {
+      return response.data.result;
+    }
+
+    throw new Error(response.data.message || '알림 목록을 불러오는데 실패했습니다.');
+  } catch (error: any) {
+    throw error;
+  }
+};
+

--- a/src/libs/api/notification.ts
+++ b/src/libs/api/notification.ts
@@ -15,12 +15,13 @@ export interface NotificationItem {
   message: string;
   imageUrl: string;
   category: 'CHALLENGE' | 'VERIFICATION' | 'FOLLOW' | 'BADGE';
-  type: 'CHALLENGE_EXTENSION' | string; // 현재는 CHALLENGE_EXTENSION만 존재, 추후 추가 예정
+  type: 'CHALLENGE_EXTENSION' | 'CHALLENGE_EXTENSION_SUCCESS' | 'CHALLENGE_EXTENSION_CANCEL' | string;
   targetType: 'CHALLENGE' | 'VERIFICATION' | 'COMMENT' | 'USER' | 'BADGE' | 'ROUND'; // 화면 이동을 위한 타입
   targetId: number;
   contextType: 'CHALLENGE' | 'VERIFICATION' | 'COMMENT' | 'USER' | 'BADGE' | 'ROUND'; // 추가 처리를 위한 타입
   contextId: number;
   isRead: boolean;
+  isResponded: boolean; // 챌린지 연장 여부에 응답했는지 여부
   createdAt: string;
 }
 

--- a/src/libs/api/notification.ts
+++ b/src/libs/api/notification.ts
@@ -76,3 +76,38 @@ export const getNotifications = async (
   }
 };
 
+/**
+ * 알림 읽음 처리 응답
+ */
+export interface MarkNotificationAsReadResponse {
+  isSuccess: boolean;
+  status: string;
+  code: string;
+  message: string;
+  result: {
+    notificationId: number;
+    isRead: boolean;
+  };
+}
+
+/**
+ * 알림 읽음 처리
+ */
+export const markNotificationAsRead = async (
+  notificationId: number
+): Promise<MarkNotificationAsReadResponse['result']> => {
+  try {
+    const response = await apiClient.patch<MarkNotificationAsReadResponse>(
+      `/api/v1/notifications/${notificationId}/read`
+    );
+
+    if (response.data.isSuccess && response.data.result) {
+      return response.data.result;
+    }
+
+    throw new Error(response.data.message || '알림 읽음 처리에 실패했습니다.');
+  } catch (error: any) {
+    throw error;
+  }
+};
+

--- a/src/screens/CategorySearchScreen.tsx
+++ b/src/screens/CategorySearchScreen.tsx
@@ -394,7 +394,6 @@ const styles = StyleSheet.create({
     ...typography.smReg,
     color: colors.icon.gray,
     textAlign: 'center',
-    lineHeight: verticalScale(21),
     marginTop: verticalScale(16),
   },
 });

--- a/src/screens/ChallengeListScreen.tsx
+++ b/src/screens/ChallengeListScreen.tsx
@@ -447,7 +447,6 @@ const styles = StyleSheet.create({
     ...typography.smReg,
     color: colors.icon.gray,
     textAlign: 'center',
-    lineHeight: verticalScale(21),
     marginTop: verticalScale(32),
   },
   errorText: {

--- a/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
@@ -600,7 +600,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
 
         {/* 링크 */}
         {verification.textUrl && (
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.linkBox}
             onPress={() => {
               Linking.canOpenURL(verification.textUrl).then(supported => {
@@ -1036,7 +1036,6 @@ const styles = StyleSheet.create({
   },
   content: {
     marginBottom: verticalScale(16),
-    lineHeight: verticalScale(18),
   },
   linkBox: {
     height: verticalScale(48),

--- a/src/screens/ChallengeProfile/ChallengeCertificationPostScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationPostScreen.tsx
@@ -314,6 +314,5 @@ const styles = StyleSheet.create({
   },
   questionDescription: {
     marginTop: verticalScale(4),
-    lineHeight: verticalScale(18),
   },
 });

--- a/src/screens/ChallengeProfile/ChallengeCertificationTextEditScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationTextEditScreen.tsx
@@ -750,7 +750,6 @@ const styles = StyleSheet.create({
   },
   modalErrorText: {
     textAlign: 'left',
-    lineHeight: verticalScale(18),
   },
   modalInput: {
     ...typography.smReg,

--- a/src/screens/ChallengeProfile/ChallengeCertificationTextScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationTextScreen.tsx
@@ -705,7 +705,6 @@ const styles = StyleSheet.create({
   },
   questionDescription: {
     marginTop: verticalScale(4),
-    lineHeight: verticalScale(18),
   },
   keyboardAvoidingView: {
     position: 'absolute',

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -1,18 +1,65 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
 import { scale, verticalScale } from '../utils/scaling';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RootStackParamList } from '../navigation/types';
 import { colors, typography } from '../design/tokens';
 import { Header } from '../components/common/Header';
+import { NotificationItem } from '../components/notification/NotificationItem';
 import LogoGray from '../../assets/images/logo-gray.svg';
+
+// 임시 데이터 타입 (API 연동 전)
+interface NotificationItemData {
+  id: string;
+  type: 'normal' | 'challenge_ending';
+  profileImage: number;
+  title: string;
+  description: string;
+  timeAgo: string;
+  isRead: boolean;
+}
 
 const NotificationsScreen = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   const [activeFilter, setActiveFilter] = useState<string>('챌린지');
 
-  const filters = ['챌린지', '인증', '팔로우', '뱃지'];
+  // const filters = ['챌린지', '인증', '팔로우', '뱃지'];
+  const filters = ['챌린지'];  // 1차 구현
+
+  // 임시 데이터 (API 연동 전)
+  const mockNotifications: NotificationItemData[] = [
+    {
+      id: '1',
+      type: 'normal',
+      profileImage: require('../../assets/images/mock-challenge-profile.png'),
+      title: '빈자리가 있어요',
+      description: '자잘자잘 챌린지에 빈자리가 생겼어요! 지금 바로 챌린지에 참여해보세요',
+      timeAgo: '1분 전',
+      isRead: false,
+    },
+    {
+      id: '2',
+      type: 'challenge_ending',
+      profileImage: require('../../assets/images/mock-challenge-profile.png'),
+      title: '정처기 챌린지 종료 3일 전이에요',
+      description: '다음 라운드에도 참여하시겠어요?\n내일까지 연장 여부를 알려주세요!',
+      timeAgo: '1분 전',
+      isRead: true,
+    },
+  ];
+
+  const handleYesPress = (id: string) => {
+    console.log('네 버튼 클릭:', id);
+    // TODO: API 연동
+  };
+
+  const handleNoPress = (id: string) => {
+    console.log('아니오 버튼 클릭:', id);
+    // TODO: API 연동
+  };
+
+  const hasNotifications = mockNotifications.length > 0;
 
   return (
     <View style={styles.container}>
@@ -22,7 +69,7 @@ const NotificationsScreen = () => {
         showDivider={true}
         useSafeArea={true}
       />
-      
+
       <View style={styles.filterContainer}>
         {filters.map((filter) => (
           <TouchableOpacity
@@ -45,10 +92,28 @@ const NotificationsScreen = () => {
         ))}
       </View>
 
-      <View style={styles.emptyContainer}>
-        <LogoGray width={124.16} height={119.79} />
-        <Text style={styles.emptyText}>받은 알림이 없어요</Text>
-      </View>
+      {hasNotifications ? (
+        <ScrollView style={styles.notificationList}>
+          {mockNotifications.map((item) => (
+            <NotificationItem
+              key={item.id}
+              type={item.type}
+              profileImage={item.profileImage}
+              title={item.title}
+              description={item.description}
+              timeAgo={item.timeAgo}
+              isRead={item.isRead}
+              onYesPress={() => handleYesPress(item.id)}
+              onNoPress={() => handleNoPress(item.id)}
+            />
+          ))}
+        </ScrollView>
+      ) : (
+        <View style={styles.emptyContainer}>
+          <LogoGray width={124.16} height={119.79} />
+          <Text style={styles.emptyText}>받은 알림이 없어요</Text>
+        </View>
+      )}
     </View>
   );
 };
@@ -69,7 +134,7 @@ const styles = StyleSheet.create({
   filterButton: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: scale(12),
+    paddingHorizontal: scale(14),
     paddingVertical: verticalScale(6),
     borderRadius: scale(20),
     backgroundColor: colors.white,
@@ -97,6 +162,9 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     lineHeight: verticalScale(21),
     marginTop: verticalScale(32),
+  },
+  notificationList: {
+    flex: 1,
   },
 });
 

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView, ActivityIndicator, Alert } from 'react-native';
 import { scale, verticalScale } from '../utils/scaling';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RootStackParamList } from '../navigation/types';
 import { colors, typography } from '../design/tokens';
@@ -64,6 +64,13 @@ const NotificationsScreen = () => {
   useEffect(() => {
     fetchNotifications(activeCategory, 1);
   }, [activeCategory]);
+
+  // 화면 포커스 시 알림 목록 새로고침
+  useFocusEffect(
+    React.useCallback(() => {
+      fetchNotifications(activeCategory, 1);
+    }, [activeCategory])
+  );
 
   // 시간 포맷팅 함수
   const formatTimeAgo = (dateString: string): string => {
@@ -133,6 +140,25 @@ const NotificationsScreen = () => {
 
     try {
       await submitRoundDecision(challengeId, 'CONTINUE');
+
+      // 서버에 읽음 처리 요청
+      try {
+        await markNotificationAsRead(id);
+      } catch (error) {
+        // 읽음 처리 실패해도 계속 진행
+      }
+
+      // 로컬 state 업데이트
+      setNotifications(prev =>
+        prev.map(item =>
+          item.id === id ? { ...item, isRead: true, isResponded: true } : item
+        )
+      );
+
+      // 성공 시 알림 목록 새로고침하여 새 알림 반영
+      setTimeout(() => {
+        fetchNotifications(activeCategory, 1);
+      }, 1000);
     } catch (error: any) {
       const errorMessage = error.response?.data?.message || '챌린지 연장 여부 제출에 실패했습니다.';
       Alert.alert('알림', errorMessage);
@@ -147,6 +173,25 @@ const NotificationsScreen = () => {
 
     try {
       await submitRoundDecision(challengeId, 'STOP');
+
+      // 서버에 읽음 처리 요청
+      try {
+        await markNotificationAsRead(id);
+      } catch (error) {
+        // 읽음 처리 실패해도 계속 진행
+      }
+
+      // 로컬 state 업데이트
+      setNotifications(prev =>
+        prev.map(item =>
+          item.id === id ? { ...item, isRead: true, isResponded: true } : item
+        )
+      );
+
+      // 성공 시 알림 목록 새로고침하여 새 알림 반영
+      setTimeout(() => {
+        fetchNotifications(activeCategory, 1);
+      }, 1000);
     } catch (error: any) {
       const errorMessage = error.response?.data?.message || '챌린지 연장 여부 제출에 실패했습니다.';
       Alert.alert('알림', errorMessage);
@@ -201,6 +246,7 @@ const NotificationsScreen = () => {
               description={item.message.replace(/\\n/g, '\n')}
               timeAgo={formatTimeAgo(item.createdAt)}
               isRead={item.isRead}
+              showButtons={!item.isResponded}
               onPress={() => handleNotificationPress(item)}
               onYesPress={() => handleYesPress(item.id)}
               onNoPress={() => handleNoPress(item.id)}

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ScrollView, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView, ActivityIndicator, Alert } from 'react-native';
 import { scale, verticalScale } from '../utils/scaling';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -12,6 +12,7 @@ import {
   markNotificationAsRead,
   NotificationItem as NotificationItemType
 } from '../libs/api/notification';
+import { submitRoundDecision } from '../libs/api/challenge';
 import LogoGray from '../../assets/images/logo-gray.svg';
 
 // 카테고리 매핑
@@ -53,7 +54,7 @@ const NotificationsScreen = () => {
       setHasNext(result.hasNext);
       setPage(pageNum);
     } catch (error) {
-      console.error('알림 목록 조회 실패:', error);
+      // 에러 무시
     } finally {
       setLoading(false);
     }
@@ -112,7 +113,7 @@ const NotificationsScreen = () => {
           );
         }
       } catch (error) {
-        console.error('알림 읽음 처리 실패:', error);
+        // 에러 무시
       }
     }
 
@@ -124,14 +125,32 @@ const NotificationsScreen = () => {
     }
   };
 
-  const handleYesPress = (id: number) => {
-    console.log('네 버튼 클릭:', id);
-    // TODO: 챌린지 연장 여부 제출 API 연동
+  const handleYesPress = async (id: number) => {
+    const notification = notifications.find(n => n.id === id);
+    if (!notification) return;
+
+    const challengeId = notification.targetId;
+
+    try {
+      await submitRoundDecision(challengeId, 'CONTINUE');
+    } catch (error: any) {
+      const errorMessage = error.response?.data?.message || '챌린지 연장 여부 제출에 실패했습니다.';
+      Alert.alert('알림', errorMessage);
+    }
   };
 
-  const handleNoPress = (id: number) => {
-    console.log('아니오 버튼 클릭:', id);
-    // TODO: 챌린지 연장 여부 제출 API 연동
+  const handleNoPress = async (id: number) => {
+    const notification = notifications.find(n => n.id === id);
+    if (!notification) return;
+
+    const challengeId = notification.targetId;
+
+    try {
+      await submitRoundDecision(challengeId, 'STOP');
+    } catch (error: any) {
+      const errorMessage = error.response?.data?.message || '챌린지 연장 여부 제출에 실패했습니다.';
+      Alert.alert('알림', errorMessage);
+    }
   };
 
   const hasNotifications = notifications.length > 0;

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -9,6 +9,7 @@ import { Header } from '../components/common/Header';
 import { NotificationItem as NotificationItemComponent } from '../components/notification/NotificationItem';
 import {
   getNotifications,
+  markNotificationAsRead,
   NotificationItem as NotificationItemType
 } from '../libs/api/notification';
 import LogoGray from '../../assets/images/logo-gray.svg';
@@ -93,6 +94,26 @@ const NotificationsScreen = () => {
     return type === 'CHALLENGE_EXTENSION' ? 'challenge_ending' : 'normal';
   };
 
+  // 알림 읽음 처리
+  const handleNotificationRead = async (notificationId: number) => {
+    try {
+      const result = await markNotificationAsRead(notificationId);
+
+      // 로컬 state 업데이트 (배경색 변경)
+      if (result.isRead) {
+        setNotifications(prev =>
+          prev.map(notification =>
+            notification.id === notificationId
+              ? { ...notification, isRead: true }
+              : notification
+          )
+        );
+      }
+    } catch (error) {
+      console.error('알림 읽음 처리 실패:', error);
+    }
+  };
+
   const handleYesPress = (id: number) => {
     console.log('네 버튼 클릭:', id);
     // TODO: 챌린지 연장 여부 제출 API 연동
@@ -151,6 +172,7 @@ const NotificationsScreen = () => {
               description={item.message.replace(/\\n/g, '\n')}
               timeAgo={formatTimeAgo(item.createdAt)}
               isRead={item.isRead}
+              onPress={() => !item.isRead && handleNotificationRead(item.id)}
               onYesPress={() => handleYesPress(item.id)}
               onNoPress={() => handleNoPress(item.id)}
             />

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -118,8 +118,8 @@ const NotificationsScreen = () => {
 
     // 화면 이동
     if (notification.targetType === 'CHALLENGE') {
-      navigation.navigate('ChallengeProfile', { 
-        challengeId: notification.targetId 
+      navigation.navigate('ChallengeProfile', {
+        challengeId: notification.targetId
       });
     }
   };
@@ -245,7 +245,6 @@ const styles = StyleSheet.create({
     ...typography.smReg,
     color: colors.icon.gray,
     textAlign: 'center',
-    lineHeight: verticalScale(21),
     marginTop: verticalScale(32),
   },
   notificationList: {

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -94,23 +94,33 @@ const NotificationsScreen = () => {
     return type === 'CHALLENGE_EXTENSION' ? 'challenge_ending' : 'normal';
   };
 
-  // 알림 읽음 처리
-  const handleNotificationRead = async (notificationId: number) => {
-    try {
-      const result = await markNotificationAsRead(notificationId);
+  // 알림 클릭 처리 (읽음 처리 + 화면 이동)
+  const handleNotificationPress = async (notification: NotificationItemType) => {
+    // 읽지 않은 알림만 읽음 처리
+    if (!notification.isRead) {
+      try {
+        const result = await markNotificationAsRead(notification.id);
 
-      // 로컬 state 업데이트 (배경색 변경)
-      if (result.isRead) {
-        setNotifications(prev =>
-          prev.map(notification =>
-            notification.id === notificationId
-              ? { ...notification, isRead: true }
-              : notification
-          )
-        );
+        // 로컬 state 업데이트 (배경색 변경)
+        if (result.isRead) {
+          setNotifications(prev =>
+            prev.map(item =>
+              item.id === notification.id
+                ? { ...item, isRead: true }
+                : item
+            )
+          );
+        }
+      } catch (error) {
+        console.error('알림 읽음 처리 실패:', error);
       }
-    } catch (error) {
-      console.error('알림 읽음 처리 실패:', error);
+    }
+
+    // 화면 이동
+    if (notification.targetType === 'CHALLENGE') {
+      navigation.navigate('ChallengeProfile', { 
+        challengeId: notification.targetId 
+      });
     }
   };
 
@@ -172,7 +182,7 @@ const NotificationsScreen = () => {
               description={item.message.replace(/\\n/g, '\n')}
               timeAgo={formatTimeAgo(item.createdAt)}
               isRead={item.isRead}
-              onPress={() => !item.isRead && handleNotificationRead(item.id)}
+              onPress={() => handleNotificationPress(item)}
               onYesPress={() => handleYesPress(item.id)}
               onNoPress={() => handleNoPress(item.id)}
             />

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -1,65 +1,109 @@
-import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView, ActivityIndicator } from 'react-native';
 import { scale, verticalScale } from '../utils/scaling';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RootStackParamList } from '../navigation/types';
 import { colors, typography } from '../design/tokens';
 import { Header } from '../components/common/Header';
-import { NotificationItem } from '../components/notification/NotificationItem';
+import { NotificationItem as NotificationItemComponent } from '../components/notification/NotificationItem';
+import {
+  getNotifications,
+  NotificationItem as NotificationItemType
+} from '../libs/api/notification';
 import LogoGray from '../../assets/images/logo-gray.svg';
 
-// 임시 데이터 타입 (API 연동 전)
-interface NotificationItemData {
-  id: string;
-  type: 'normal' | 'challenge_ending';
-  profileImage: number;
-  title: string;
-  description: string;
-  timeAgo: string;
-  isRead: boolean;
+// 카테고리 매핑
+interface CategoryInfo {
+  label: string;
+  value: 'CHALLENGE' | 'VERIFICATION' | 'FOLLOW' | 'BADGE';
 }
+
+const CATEGORIES: CategoryInfo[] = [
+  { label: '챌린지', value: 'CHALLENGE' },
+  // { label: '인증', value: 'VERIFICATION' },
+  // { label: '팔로우', value: 'FOLLOW' },
+  // { label: '뱃지', value: 'BADGE' },
+];
 
 const NotificationsScreen = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
-  const [activeFilter, setActiveFilter] = useState<string>('챌린지');
+  const [activeCategory, setActiveCategory] = useState<'CHALLENGE' | 'VERIFICATION' | 'FOLLOW' | 'BADGE'>('CHALLENGE');
+  const [notifications, setNotifications] = useState<NotificationItemType[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [hasNext, setHasNext] = useState(false);
 
-  // const filters = ['챌린지', '인증', '팔로우', '뱃지'];
-  const filters = ['챌린지'];  // 1차 구현
+  // 알림 목록 조회
+  const fetchNotifications = async (category: 'CHALLENGE' | 'VERIFICATION' | 'FOLLOW' | 'BADGE', pageNum: number = 1) => {
+    try {
+      setLoading(true);
+      const result = await getNotifications({
+        category,
+        page: pageNum,
+        size: 10,
+      });
 
-  // 임시 데이터 (API 연동 전)
-  const mockNotifications: NotificationItemData[] = [
-    {
-      id: '1',
-      type: 'normal',
-      profileImage: require('../../assets/images/mock-challenge-profile.png'),
-      title: '빈자리가 있어요',
-      description: '자잘자잘 챌린지에 빈자리가 생겼어요! 지금 바로 챌린지에 참여해보세요',
-      timeAgo: '1분 전',
-      isRead: false,
-    },
-    {
-      id: '2',
-      type: 'challenge_ending',
-      profileImage: require('../../assets/images/mock-challenge-profile.png'),
-      title: '정처기 챌린지 종료 3일 전이에요',
-      description: '다음 라운드에도 참여하시겠어요?\n내일까지 연장 여부를 알려주세요!',
-      timeAgo: '1분 전',
-      isRead: true,
-    },
-  ];
+      if (pageNum === 1) {
+        setNotifications(result.content);
+      } else {
+        setNotifications(prev => [...prev, ...result.content]);
+      }
+      setHasNext(result.hasNext);
+      setPage(pageNum);
+    } catch (error) {
+      console.error('알림 목록 조회 실패:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
 
-  const handleYesPress = (id: string) => {
+  // 카테고리 변경 시 알림 목록 재조회
+  useEffect(() => {
+    fetchNotifications(activeCategory, 1);
+  }, [activeCategory]);
+
+  // 시간 포맷팅 함수
+  const formatTimeAgo = (dateString: string): string => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffInMs = now.getTime() - date.getTime();
+    const diffInMinutes = Math.floor(diffInMs / (1000 * 60));
+    const diffInHours = Math.floor(diffInMs / (1000 * 60 * 60));
+    const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
+
+    if (diffInMinutes < 1) {
+      return '방금 전';
+    } else if (diffInMinutes < 60) {
+      return `${diffInMinutes}분 전`;
+    } else if (diffInHours < 24) {
+      return `${diffInHours}시간 전`;
+    } else if (diffInDays < 7) {
+      return `${diffInDays}일 전`;
+    } else {
+      const year = date.getFullYear().toString().slice(-2);
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      return `${year}.${month}.${day}`;
+    }
+  };
+
+  // 알림 타입에 따른 컴포넌트 타입 결정
+  const getNotificationComponentType = (type: string): 'normal' | 'challenge_ending' => {
+    return type === 'CHALLENGE_EXTENSION' ? 'challenge_ending' : 'normal';
+  };
+
+  const handleYesPress = (id: number) => {
     console.log('네 버튼 클릭:', id);
-    // TODO: API 연동
+    // TODO: 챌린지 연장 여부 제출 API 연동
   };
 
-  const handleNoPress = (id: string) => {
+  const handleNoPress = (id: number) => {
     console.log('아니오 버튼 클릭:', id);
-    // TODO: API 연동
+    // TODO: 챌린지 연장 여부 제출 API 연동
   };
 
-  const hasNotifications = mockNotifications.length > 0;
+  const hasNotifications = notifications.length > 0;
 
   return (
     <View style={styles.container}>
@@ -71,42 +115,51 @@ const NotificationsScreen = () => {
       />
 
       <View style={styles.filterContainer}>
-        {filters.map((filter) => (
+        {CATEGORIES.map((category) => (
           <TouchableOpacity
-            key={filter}
+            key={category.value}
             style={[
               styles.filterButton,
-              activeFilter === filter && styles.filterButtonActive,
+              activeCategory === category.value && styles.filterButtonActive,
             ]}
-            onPress={() => setActiveFilter(filter)}
+            onPress={() => setActiveCategory(category.value)}
           >
             <Text
               style={[
                 styles.filterButtonText,
-                activeFilter === filter && styles.filterButtonTextActive,
+                activeCategory === category.value && styles.filterButtonTextActive,
               ]}
             >
-              {filter}
+              {category.label}
             </Text>
           </TouchableOpacity>
         ))}
       </View>
 
-      {hasNotifications ? (
+      {loading && page === 1 ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={colors.primary.main} />
+        </View>
+      ) : hasNotifications ? (
         <ScrollView style={styles.notificationList}>
-          {mockNotifications.map((item) => (
-            <NotificationItem
+          {notifications.map((item) => (
+            <NotificationItemComponent
               key={item.id}
-              type={item.type}
-              profileImage={item.profileImage}
+              type={getNotificationComponentType(item.type)}
+              profileImage={item.imageUrl ? { uri: item.imageUrl } : require('../../assets/images/mock-challenge-profile.png')}
               title={item.title}
-              description={item.description}
-              timeAgo={item.timeAgo}
+              description={item.message.replace(/\\n/g, '\n')}
+              timeAgo={formatTimeAgo(item.createdAt)}
               isRead={item.isRead}
               onYesPress={() => handleYesPress(item.id)}
               onNoPress={() => handleNoPress(item.id)}
             />
           ))}
+          {loading && page > 1 && (
+            <View style={styles.loadingMoreContainer}>
+              <ActivityIndicator size="small" color={colors.primary.main} />
+            </View>
+          )}
         </ScrollView>
       ) : (
         <View style={styles.emptyContainer}>
@@ -165,6 +218,15 @@ const styles = StyleSheet.create({
   },
   notificationList: {
     flex: 1,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loadingMoreContainer: {
+    paddingVertical: verticalScale(20),
+    alignItems: 'center',
   },
 });
 

--- a/src/screens/PopularChallengeScreen.tsx
+++ b/src/screens/PopularChallengeScreen.tsx
@@ -145,7 +145,6 @@ const styles = StyleSheet.create({
     ...typography.smReg,
     color: colors.icon.gray,
     textAlign: 'center',
-    lineHeight: verticalScale(21),
     marginTop: verticalScale(32),
   },
 });


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
알림 목록에서 사용자가 확인할 수 있는 개별 알림 아이템 UI를 구현하고, 알림 조회 및 읽음 처리/챌린지 라운드 연장 여부 확인까지 이어지는 알림 플로우 전반의 API를 연동했습니다

## 🔗 관련 이슈
close #35
<!-- 참고용: ref #이슈번호 -->

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [x] 새로운 기능
- [ ] 버그 수정
- [x] UI/UX 개선
- [x] 리팩토링
- [ ] 의존성 변경

## 📸 스크린샷
### iOS
| 읽지 않은 알림 O | 읽지 않은 알림 X | 챌린지 연장 확인 알림 | 챌린지 연장 여부 제출 이후 |
|---|---|---|---|
|<img width="300" height="1311" alt="IMG_6577" src="https://github.com/user-attachments/assets/2e29276f-5859-4d30-a3e8-9fbe01a9cd39" />|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/4ad0ded1-b0b3-4f01-9aa4-e492bb74fcd0" />|<img width="300" height="1311" alt="IMG_6583" src="https://github.com/user-attachments/assets/cb5d1644-e3ac-48e7-a344-3edd20e5a73d" />|<img width="300" height="1311" alt="IMG_6584" src="https://github.com/user-attachments/assets/7f282c2d-f2f3-49d8-9bff-e9ea22ca9b19" />|


## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
- 기존 알림의 카테고리는 정리하고 1차 런칭 UI에 맞게 `챌린지` 카테고리칩만 남아있는 상태입니다
- FCM 알림 기능은 아직 구현되지 않아 알림 목록에서만 확인이 가능합니다
- 챌린지 연장 확인 이후의 로직은 기획안과 다르게 구현된 부분이 있어 QA 기간 내에 논의를 거친 후 수정 예정입니다
- @sehwanii 그리고 일부 기기에서 글자 높이가 잘리는 문제가 발생해서 디자인 토큰 `typography` 내에 `lineHeight`를 일괄 추가하였으며 중복된 스타일은 삭제했습니다~!