### PR TITLE
[REFACTOR] 댓글 마스킹 정책 반영

### DIFF
--- a/src/components/challenge/CommentItem.tsx
+++ b/src/components/challenge/CommentItem.tsx
@@ -28,6 +28,7 @@ interface CommentItemProps {
   isQuestion?: boolean;
   isResolved?: boolean;
   replyCount?: number;
+  canSelectComment?: boolean; // 게시글 작성자만 채택 가능
 }
 
 export const CommentItem: React.FC<CommentItemProps> = ({
@@ -45,6 +46,7 @@ export const CommentItem: React.FC<CommentItemProps> = ({
   isQuestion = false,
   isResolved = false,
   replyCount = 0,
+  canSelectComment = false,
 }) => {
 
   const formatDate = (dateString: string): string => {
@@ -178,7 +180,7 @@ export const CommentItem: React.FC<CommentItemProps> = ({
             </TouchableOpacity>
           )}
 
-          {isQuestion && !isMine && (
+          {isQuestion && canSelectComment && !isMine && (
             <TouchableOpacity
               style={styles.actionButton}
               activeOpacity={0.7}

--- a/src/components/challenge/CommentItem.tsx
+++ b/src/components/challenge/CommentItem.tsx
@@ -19,6 +19,7 @@ interface CommentItemProps {
   onReply?: () => void;
   onDelete?: (commentId: number) => void;
   onAdopt?: (commentId: number) => void;
+  onBlock?: (commentId: number) => void; // 댓글 작성자 차단
   isLiked?: boolean;
   isMine?: boolean;
   currentUserNickname?: string;
@@ -37,6 +38,7 @@ export const CommentItem: React.FC<CommentItemProps> = ({
   onReply,
   onDelete,
   onAdopt,
+  onBlock,
   isLiked = false,
   isMine = false,
   currentUserNickname,
@@ -104,6 +106,22 @@ export const CommentItem: React.FC<CommentItemProps> = ({
     );
   };
 
+  const handleBlock = () => {
+    onMenuToggle?.(comment.commentId);
+    Alert.alert(
+      '차단',
+      '이 댓글 작성자를 차단하시겠습니까?',
+      [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '차단',
+          style: 'destructive',
+          onPress: () => onBlock?.(comment.commentId),
+        },
+      ]
+    );
+  };
+
   return (
     <View
       onLayout={(event) => {
@@ -151,7 +169,7 @@ export const CommentItem: React.FC<CommentItemProps> = ({
                   </>
                 )}
               </View>
-              {isMine && !isMasked && (
+              {!isMasked && (
                 <TouchableOpacity
                   onPress={() => onMenuToggle?.(comment.commentId)}
                   activeOpacity={0.7}
@@ -174,9 +192,11 @@ export const CommentItem: React.FC<CommentItemProps> = ({
           </>
         )}
 
-        {/* 마스킹되지 않은 댓글만 액션 버튼 표시 */}
-        {!isMasked && (
-          <View style={styles.actionsRow}>
+        {/* 액션 버튼 */}
+        <View style={styles.actionsRow}>
+          {/* 좋아요: 1차 런칭 제외 */}
+          {/* TODO: 2차 런칭 시 좋아요 기능 추가 */}
+          {/* {!isMasked && (
             <TouchableOpacity
               style={styles.actionButton}
               activeOpacity={0.7}
@@ -191,36 +211,38 @@ export const CommentItem: React.FC<CommentItemProps> = ({
                 {comment.likesCount || 0}
               </Text>
             </TouchableOpacity>
+          )} */}
 
-            {!isReply && (
-              <TouchableOpacity
-                style={styles.actionButton}
-                activeOpacity={0.7}
-                onPress={onReply}
-              >
-                <CommentIcon width={12} height={12} />
-                <Text variant="xxs" color={colors.text.tertiary} style={styles.actionText}>
-                  {replyCount}
-                </Text>
-              </TouchableOpacity>
-            )}
+          {/* 답글: 항상 표시 */}
+          {!isReply && (
+            <TouchableOpacity
+              style={styles.actionButton}
+              activeOpacity={0.7}
+              onPress={onReply}
+            >
+              <CommentIcon width={12} height={12} />
+              <Text variant="xxs" color={colors.text.tertiary} style={styles.actionText}>
+                {replyCount}
+              </Text>
+            </TouchableOpacity>
+          )}
 
-            {isQuestion && (comment.adopted || (canSelectComment && !isMine)) && (
-              <TouchableOpacity
-                style={styles.actionButton}
-                activeOpacity={0.7}
-                onPress={() => onAdopt?.(comment.commentId)}
-                disabled={comment.adopted || isResolved}
-              >
-                {comment.adopted ? (
-                  <AdoptedIcon width={52} height={20} />
-                ) : (
-                  <AdoptableIcon width={52} height={20} />
-                )}
-              </TouchableOpacity>
-            )}
-          </View>
-        )}
+          {/* 채택: 마스킹되지 않은 경우만 */}
+          {!isMasked && isQuestion && (comment.adopted || (canSelectComment && !isMine)) && (
+            <TouchableOpacity
+              style={styles.actionButton}
+              activeOpacity={0.7}
+              onPress={() => onAdopt?.(comment.commentId)}
+              disabled={comment.adopted || isResolved}
+            >
+              {comment.adopted ? (
+                <AdoptedIcon width={52} height={20} />
+              ) : (
+                <AdoptableIcon width={52} height={20} />
+              )}
+            </TouchableOpacity>
+          )}
+        </View>
       </View>
 
       {/* 더보기 메뉴 */}
@@ -234,7 +256,7 @@ export const CommentItem: React.FC<CommentItemProps> = ({
 
           <View style={[
             styles.moreMenuContainer,
-            isMine && styles.singleMenuContainer
+            styles.singleMenuContainer
           ]}>
             {isMine ? (
               // 내가 쓴 댓글인 경우 삭제만
@@ -248,36 +270,16 @@ export const CommentItem: React.FC<CommentItemProps> = ({
                 </Text>
               </TouchableOpacity>
             ) : (
-              // 남이 쓴 댓글인 경우 채팅하기/차단
-              <>
-                <TouchableOpacity
-                  style={styles.menuButton}
-                  activeOpacity={0.9}
-                  onPress={() => {
-                    onMenuToggle?.(comment.commentId);
-                    // TODO: 채팅하기 기능
-                  }}
-                >
-                  <Text variant="md" color={colors.text.primary}>
-                    채팅하기
-                  </Text>
-                </TouchableOpacity>
-
-                <View style={styles.menuDivider} />
-
-                <TouchableOpacity
-                  style={styles.menuButton}
-                  activeOpacity={0.9}
-                  onPress={() => {
-                    onMenuToggle?.(comment.commentId);
-                    // TODO: 차단 기능
-                  }}
-                >
-                  <Text variant="md" color={colors.primary.sub}>
-                    차단
-                  </Text>
-                </TouchableOpacity>
-              </>
+              // 남이 쓴 댓글인 경우 차단만
+              <TouchableOpacity
+                style={styles.singleMenuButton}
+                activeOpacity={0.9}
+                onPress={handleBlock}
+              >
+                <Text variant="md" color={colors.primary.sub}>
+                  차단
+                </Text>
+              </TouchableOpacity>
             )}
           </View>
         </>
@@ -358,7 +360,7 @@ const styles = StyleSheet.create({
   moreMenuContainer: {
     position: 'absolute',
     right: scale(0),
-    top: scale(24),
+    top: scale(32),
     width: scale(160),
     height: verticalScale(92),
     backgroundColor: colors.white,

--- a/src/components/challenge/CommentItem.tsx
+++ b/src/components/challenge/CommentItem.tsx
@@ -84,7 +84,7 @@ export const CommentItem: React.FC<CommentItemProps> = ({
   const isDeleted = comment.userName === "삭제";
   const isBlocked = comment.content === "차단된 사용자의 댓글입니다.";
   const isInactive = comment.content === "탈퇴한 사용자의 댓글입니다.";
-  
+
   // 프로필 이미지 표시 여부 (모든 마스킹 케이스에서 숨김)
   const showProfile = !isMasked;
 
@@ -136,8 +136,8 @@ export const CommentItem: React.FC<CommentItemProps> = ({
                     <LockIcon width={10} height={12} />
                   </View>
                 )}
-                <Text 
-                  variant="smMd" 
+                <Text
+                  variant="smMd"
                   color={isMasked ? colors.text.secondary : colors.text.primary}
                 >
                   {comment.userName}
@@ -164,8 +164,8 @@ export const CommentItem: React.FC<CommentItemProps> = ({
             </View>
 
             {/* 댓글 텍스트 */}
-            <Text 
-              variant="xsReg" 
+            <Text
+              variant="xsReg"
               color={colors.text.secondary}
               style={styles.commentText}
             >
@@ -205,7 +205,7 @@ export const CommentItem: React.FC<CommentItemProps> = ({
               </TouchableOpacity>
             )}
 
-            {isQuestion && canSelectComment && !isMine && (
+            {isQuestion && (comment.adopted || (canSelectComment && !isMine)) && (
               <TouchableOpacity
                 style={styles.actionButton}
                 activeOpacity={0.7}

--- a/src/components/challenge/CommentItem.tsx
+++ b/src/components/challenge/CommentItem.tsx
@@ -79,12 +79,14 @@ export const CommentItem: React.FC<CommentItemProps> = ({
   // 대댓글인 경우 왼쪽 여백 추가
   const isReply = comment.depth > 0;
 
-  // 표시할 닉네임 결정
-  // TODO: 백엔드 API 수정 이후 변경 필요
-  const displayName =
-    isMine
-      ? currentUserNickname
-      : comment.userName;
+  // 마스킹된 댓글 여부 및 타입 확인
+  const isMasked = comment.userId === null;
+  const isDeleted = comment.userName === "삭제";
+  const isBlocked = comment.content === "차단된 사용자의 댓글입니다.";
+  const isInactive = comment.content === "탈퇴한 사용자의 댓글입니다.";
+  
+  // 프로필 이미지 표시 여부 (모든 마스킹 케이스에서 숨김)
+  const showProfile = !isMasked;
 
   const handleDelete = () => {
     onMenuToggle?.(comment.commentId);
@@ -110,91 +112,115 @@ export const CommentItem: React.FC<CommentItemProps> = ({
       }}
       style={[styles.container, isReply && styles.replyContainer]}
     >
-      {/* 프로필 이미지 */}
-      <View style={styles.profileContainer}>
-        <DefaultProfileIcon width={32} height={32} />
-      </View>
+      {/* 프로필 이미지 - 삭제/탈퇴는 숨김 */}
+      {showProfile && (
+        <View style={styles.profileContainer}>
+          <DefaultProfileIcon width={32} height={32} />
+        </View>
+      )}
 
       {/* 댓글 내용 */}
-      <View style={styles.contentContainer}>
-        {/* 사용자 닉네임과 작성 시간 */}
-        <View style={styles.headerRow}>
-          <View style={styles.userInfoRow}>
-            {comment.anonymous && (
-              <View style={styles.lockIconContainer}>
-                <LockIcon width={10} height={12} />
+      <View style={[styles.contentContainer, !showProfile && styles.contentContainerNoProfile]}>
+        {isBlocked ? (
+          /* 차단된 사용자 - userName 없이 content만 표시 */
+          <Text variant="xsReg" color={colors.text.tertiary} style={styles.commentText}>
+            {comment.content}
+          </Text>
+        ) : (
+          <>
+            {/* 사용자 닉네임과 작성 시간 */}
+            <View style={styles.headerRow}>
+              <View style={styles.userInfoRow}>
+                {comment.anonymous && !isMasked && (
+                  <View style={styles.lockIconContainer}>
+                    <LockIcon width={10} height={12} />
+                  </View>
+                )}
+                <Text 
+                  variant="smMd" 
+                  color={isMasked ? colors.text.secondary : colors.text.primary}
+                >
+                  {comment.userName}
+                </Text>
+                {!isMasked && (
+                  <>
+                    <View style={styles.dot} />
+                    <Text variant="xxs" color={colors.icon.gray}>
+                      {formatDate(comment.createdAt)}
+                    </Text>
+                  </>
+                )}
               </View>
-            )}
-            <Text variant="smMd" color={colors.text.primary}>
-              {displayName}
-            </Text>
-            <View style={styles.dot} />
-            <Text variant="xxs" color={colors.icon.gray}>
-              {formatDate(comment.createdAt)}
-            </Text>
-          </View>
-          {isMine && (
-            <TouchableOpacity
-              onPress={() => onMenuToggle?.(comment.commentId)}
-              activeOpacity={0.7}
-              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-              style={styles.moreButton}
+              {isMine && !isMasked && (
+                <TouchableOpacity
+                  onPress={() => onMenuToggle?.(comment.commentId)}
+                  activeOpacity={0.7}
+                  hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                  style={styles.moreButton}
+                >
+                  <MoreIcon width={15} height={3} />
+                </TouchableOpacity>
+              )}
+            </View>
+
+            {/* 댓글 텍스트 */}
+            <Text 
+              variant="xsReg" 
+              color={colors.text.secondary}
+              style={styles.commentText}
             >
-              <MoreIcon width={15} height={3} />
-            </TouchableOpacity>
-          )}
-        </View>
-
-        {/* 댓글 텍스트 */}
-        <Text variant="xsReg" color={colors.text.secondary} style={styles.commentText}>
-          {comment.content}
-        </Text>
-
-        {/* 좋아요 및 답글 버튼 */}
-        <View style={styles.actionsRow}>
-          <TouchableOpacity
-            style={styles.actionButton}
-            activeOpacity={0.7}
-            onPress={() => onLike?.(comment.commentId)}
-          >
-            {isLiked ? (
-              <LikeSelectedIcon width={14} height={12} />
-            ) : (
-              <LikeUnselectedIcon width={14} height={12} />
-            )}
-            <Text variant="xxs" color={colors.text.tertiary} style={styles.actionText}>
-              {comment.likesCount || 0}
+              {comment.content}
             </Text>
-          </TouchableOpacity>
+          </>
+        )}
 
-          {!isReply && (
+        {/* 마스킹되지 않은 댓글만 액션 버튼 표시 */}
+        {!isMasked && (
+          <View style={styles.actionsRow}>
             <TouchableOpacity
               style={styles.actionButton}
               activeOpacity={0.7}
-              onPress={onReply}
+              onPress={() => onLike?.(comment.commentId)}
             >
-              <CommentIcon width={12} height={12} />
+              {isLiked ? (
+                <LikeSelectedIcon width={14} height={12} />
+              ) : (
+                <LikeUnselectedIcon width={14} height={12} />
+              )}
               <Text variant="xxs" color={colors.text.tertiary} style={styles.actionText}>
-                {replyCount}
+                {comment.likesCount || 0}
               </Text>
             </TouchableOpacity>
-          )}
 
-          {isQuestion && canSelectComment && !isMine && (
-            <TouchableOpacity
-              style={styles.actionButton}
-              activeOpacity={0.7}
-              onPress={() => onAdopt?.(comment.commentId)}
-              disabled={comment.adopted || isResolved}
-            >
-              {comment.adopted ? (
-                <AdoptedIcon width={52} height={20} />
-              ) : (
-                <AdoptableIcon width={52} height={20} />
-              )}
-            </TouchableOpacity>
-          )}
-        </View>
+            {!isReply && (
+              <TouchableOpacity
+                style={styles.actionButton}
+                activeOpacity={0.7}
+                onPress={onReply}
+              >
+                <CommentIcon width={12} height={12} />
+                <Text variant="xxs" color={colors.text.tertiary} style={styles.actionText}>
+                  {replyCount}
+                </Text>
+              </TouchableOpacity>
+            )}
+
+            {isQuestion && canSelectComment && !isMine && (
+              <TouchableOpacity
+                style={styles.actionButton}
+                activeOpacity={0.7}
+                onPress={() => onAdopt?.(comment.commentId)}
+                disabled={comment.adopted || isResolved}
+              >
+                {comment.adopted ? (
+                  <AdoptedIcon width={52} height={20} />
+                ) : (
+                  <AdoptableIcon width={52} height={20} />
+                )}
+              </TouchableOpacity>
+            )}
+          </View>
+        )}
       </View>
 
       {/* 더보기 메뉴 */}
@@ -278,6 +304,9 @@ const styles = StyleSheet.create({
   },
   contentContainer: {
     flex: 1,
+  },
+  contentContainerNoProfile: {
+    marginLeft: 0,
   },
   headerRow: {
     flexDirection: 'row',

--- a/src/libs/api/challenge.ts
+++ b/src/libs/api/challenge.ts
@@ -1186,9 +1186,9 @@ export interface CommentItem {
   commentId: number;
   parentId: number;
   verificationId: number;
-  userId: number;
+  userId: number | null;
   userName: string;
-  userProfileUrl: string;
+  userProfileUrl: string | null;
   depth: number;
   content: string;
   likesCount: number;
@@ -1196,6 +1196,7 @@ export interface CommentItem {
   updatedAt: string;
   anonymous: boolean;
   adopted: boolean;
+  myComment: boolean;
 }
 
 /**

--- a/src/libs/api/challenge.ts
+++ b/src/libs/api/challenge.ts
@@ -1475,3 +1475,31 @@ export const reportUser = async (
     throw error;
   }
 };
+
+/**
+ * 댓글 작성자 차단 응답
+ */
+export interface BlockCommentResponse {
+  isSuccess: boolean;
+  status: string;
+  code: string;
+  message: string;
+  result: string;
+}
+
+/**
+ * 댓글 작성자 차단
+ */
+export const blockComment = async (commentId: number): Promise<void> => {
+  try {
+    const response = await apiClient.post<BlockCommentResponse>(
+      `/api/v1/comments/${commentId}/block`
+    );
+
+    if (!response.data.isSuccess) {
+      throw new Error(response.data.message || '댓글 작성자 차단에 실패했습니다.');
+    }
+  } catch (error: any) {
+    throw error;
+  }
+};

--- a/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
@@ -24,6 +24,7 @@ import {
   createComment,
   deleteComment,
   adoptComment,
+  blockComment,
   CommentItem as CommentItemType,
   GetCommentsResponse,
   reportVerificationPost,
@@ -142,7 +143,8 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
         }
       });
     } catch (error: any) {
-      Alert.alert('오류', error.message || '게시글을 불러오는데 실패했습니다.');
+      const errorMessage = error.response?.data?.message || error.message || '게시글을 불러오는데 실패했습니다.';
+      Alert.alert('오류', errorMessage);
       navigation.goBack();
     } finally {
       setIsLoading(false);
@@ -431,6 +433,27 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
     }
   };
 
+  // 댓글 작성자 차단
+  const handleBlockUser = async (commentId: number) => {
+    try {
+      await blockComment(commentId);
+
+      Alert.alert('차단 완료', '해당 사용자가 차단되었습니다.');
+
+      // 댓글 목록 새로고침 (차단된 사용자 댓글이 마스킹 처리됨)
+      if (verification) {
+        const commentsResult = await getComments(verification.verificationId, {
+          page: 1,
+          size: 10,
+        });
+        setComments(commentsResult);
+      }
+    } catch (error: any) {
+      const errorMessage = error.response?.data?.message || error.message || '사용자 차단에 실패했습니다.';
+      Alert.alert('오류', errorMessage);
+    }
+  };
+
   // 답글 펼치기/접기 토글
   const toggleRepliesExpand = (commentId: number) => {
     setExpandedComments(prev => {
@@ -707,6 +730,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
                     }}
                     onReply={() => handleReplyToComment(parent)}
                     onDelete={handleDeleteComment}
+                    onBlock={handleBlockUser}
                     onAdopt={handleAdoptComment}
                     isQuestion={verification?.isQuestion}
                     isResolved={verification?.isResolved}
@@ -752,6 +776,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
                               // TODO: 댓글 좋아요 처리
                             }}
                             onDelete={handleDeleteComment}
+                            onBlock={handleBlockUser}
                             onAdopt={handleAdoptComment}
                             isQuestion={verification?.isQuestion}
                             isResolved={verification?.isResolved}

--- a/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
@@ -508,15 +508,20 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
     return `${year}.${month}.${day} ${hours}:${minutes}`;
   };
 
-  // TODO: 백엔드 API 변경 후 수정 필요
-  const getUserRoleText = (role: string): string => {
-    switch (role) {
-      case 'OWNER':
-        return '방장';
+  const getUserLevelText = (level: string): string => {
+    switch (level) {
+      case 'BRONZE':
+        return '브론즈';
+      case 'SILVER':
+        return '실버';
+      case 'GOLD':
+        return '골드';
+      case 'MASTER':
+        return '마스터';
       case 'CHALLENGER':
         return '챌린저';
       default:
-        return '챌린저';
+        return '브론즈';
     }
   };
 
@@ -575,7 +580,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
               </Text>
               <View style={styles.dot} />
               <Text variant="smReg" color={colors.text.tertiary}>
-                {getUserRoleText(verification.user.level)}
+                {getUserLevelText(verification.user.level)}
               </Text>
             </View>
             <View style={styles.timeSpacing} />

--- a/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
@@ -681,8 +681,6 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
             }}
           >
             {getCommentTree().map(({ parent, children }, index) => {
-              const isMineParent = parent.userId === verification?.user.userId;
-
               return (
                 <View
                   key={parent.commentId}
@@ -694,7 +692,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
                   {/* 부모 댓글 */}
                   <CommentItem
                     comment={parent}
-                    isMine={isMineParent}
+                    isMine={parent.myComment}
                     currentUserNickname={verification?.user.nickname}
                     isMenuOpen={openMenuCommentId === parent.commentId}
                     onMenuToggle={handleMenuToggle}
@@ -736,12 +734,11 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
                   {expandedComments.has(parent.commentId) && (
                     <>
                       {children.map((child) => {
-                        const isMineChild = child.userId === verification?.user.userId;
                         return (
                           <CommentItem
                             key={child.commentId}
                             comment={child}
-                            isMine={isMineChild}
+                            isMine={child.myComment}
                             currentUserNickname={verification?.user.nickname}
                             isMenuOpen={openMenuCommentId === child.commentId}
                             onMenuToggle={handleMenuToggle}

--- a/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
@@ -712,6 +712,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
                     onAdopt={handleAdoptComment}
                     isQuestion={verification?.isQuestion}
                     isResolved={verification?.isResolved}
+                    canSelectComment={verification?.canSelectComment}
                     replyCount={children.length}
                   />
 
@@ -757,6 +758,7 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
                             onAdopt={handleAdoptComment}
                             isQuestion={verification?.isQuestion}
                             isResolved={verification?.isResolved}
+                            canSelectComment={verification?.canSelectComment}
                           />
                         );
                       })}


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
차단한 사용자의 댓글/탈퇴한 사용자의 댓글/삭제된 댓글 각각의 상태에 맞게 UI를 분기 처리하였으며, 그와 동시에 댓글 작성자 차단 및 채택과 관련한 UI와 권한 로직도 함께 수정하였습니다

## 🔗 관련 이슈
close #39
<!-- 참고용: ref #이슈번호 -->

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [ ] 새로운 기능
- [x] 버그 수정
- [x] UI/UX 개선
- [x] 리팩토링
- [ ] 의존성 변경

## 📸 스크린샷
### iOS
| 익명 및 차단된 사용자 |
|---|
|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/fcf5134c-a6ec-46a1-82b2-73858294fd03" />|


## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
- 댓글 마스킹 관련 로직에 대해 현재 백엔드에 로직 관련 문의를 남긴 상태입니다. 해당 내용은 QA 기간 중 기획/백엔드와의 논의 결과에 따라 로직 변경이 발생할 수 있습니다
- 그리고 부모 댓글이 삭제가 되면 자식 댓글까지 함께 삭제가 되어 삭제된 댓글일 때의 마스킹은 확인해 보지 못했습니다... 이것도 QA때 차차...
- 탈퇴한 사용자 역시 탈퇴 기능이 아직 develop 브랜치에 머지되지 않아서 아직 확인해 보지 못했습니다 이것도 QA때 차차...22
- 차단된 사용자의 댓글일 경우 다른 마스킹 경우와는 다르게 userName 조차 뜨지 않습니다 이걸 분기처리하려면 API 응답에 maskingType 필드가 있어야 할 것 같아서 추가 요청을 넣은 상태이며 현재는 일부 하드코딩되어 있어 추후 수정이 필요합니다