### PR TITLE
fix: 유저 화면 참가중인 챌린지/인증 기록 사이 여백 확대

### DIFF
--- a/src/screens/UserScreen.tsx
+++ b/src/screens/UserScreen.tsx
@@ -255,12 +255,14 @@ const UserScreen = () => {
           onPressHeader={() => navigation.navigate('ParticipatingChallenge', { userId: userId })}
           onPressItem={(item) => navigation.navigate('ChallengeProfile', { challengeId: Number(item.id) })}
         />
-        <ViewModeHeader
-          title="인증 기록"
-          initialMode={certificationViewMode}
-          onViewModeChange={(mode) => setCertificationViewMode(mode)}
-          onPressTitle={() => navigation.navigate('CertificationHistory', { userId: userId })}
-        />
+        <View style={{ marginTop: spacing.xxxl }}>
+          <ViewModeHeader
+            title="인증 기록"
+            initialMode={certificationViewMode}
+            onViewModeChange={(mode) => setCertificationViewMode(mode)}
+            onPressTitle={() => navigation.navigate('CertificationHistory', { userId: userId })}
+          />
+        </View>
         {certificationItems.length === 0 ? (
           <View style={styles.emptyCertificationContainer}>
             <Text style={styles.tabContentText}>인증 기록이 없습니다</Text>


### PR DESCRIPTION
## 📝 작업 내용
유저 화면에서 참가중인 챌린지와 인증 기록 컴포넌트 사이 여백 분리.
<img width="382" height="853" alt="image" src="https://github.com/user-attachments/assets/b9d0ee30-c3b9-4881-97f5-5c20f5f46f58" />
