### PR TITLE
[QA] 챌린지 생성 및 시간 기준 로직 개선

### DIFF
--- a/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { scale, verticalScale } from '../../utils/scaling';
+import { getDayOfWeek_KST, getSecondsSinceMidnight_KST, getTodayYYYYMMDD_KST } from '../../utils/kst';
 import {
   View,
   StyleSheet,
@@ -324,12 +325,12 @@ export const ChallengeProfileScreen: React.FC = () => {
       return;
     }
 
-    const today = new Date();
-    const startDate = new Date(data.startDate);
-    const endDate = new Date(data.endDate);
+    // 챌린지 일정 판단 (KST 기준)
+    const todayStr = getTodayYYYYMMDD_KST();
+
     const isFull = data.currentParticipantCount >= data.maxParticipantCount;
-    const isAfterEnd = today > endDate;
-    const hasStarted = today >= startDate;
+    const isAfterEnd = data.endDate < todayStr;
+    const hasStarted = data.startDate <= todayStr;
 
     // actionButtonStatus에 따라 처리
     if (data.actionButtonStatus === 'WAITLIST') {
@@ -382,9 +383,8 @@ export const ChallengeProfileScreen: React.FC = () => {
       return false;
     }
 
-    // JS Date 객체에서 현재 요일을 숫자로 가져옴
-    const today = new Date();
-    const dayOfWeek = today.getDay(); // 0(일) ~ 6(토)
+    // 인증 요일 판단 (KST 기준)
+    const dayOfWeek = getDayOfWeek_KST(); // 0(일) ~ 6(토)
 
     // 숫자를 요일로 변환
     const dayMap: { [key: number]: string } = {
@@ -407,8 +407,8 @@ export const ChallengeProfileScreen: React.FC = () => {
       return false;
     }
 
-    const now = new Date();
-    const currentTime = now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
+    // 인증 시간대 판단 (KST 기준)
+    const currentTime = getSecondsSinceMidnight_KST();
 
     // "HH:MM:SS" 형식을 초 단위로 변환
     const parseTime = (timeStr: string): number => {
@@ -428,16 +428,10 @@ export const ChallengeProfileScreen: React.FC = () => {
       return false;
     }
 
-    // 날짜만 비교 (타임존 이슈 방지)
-    const now = new Date();
-    const [year, month, day] = data.startDate.split('-').map(Number);
-    const startDate = new Date(year, month - 1, day); // 로컬 타임존으로 파싱
+    // 챌린지 시작 여부 판단 (KST 기준)
+    const todayStr = getTodayYYYYMMDD_KST();
 
-    // 시간 부분 제거하고 날짜만 비교
-    now.setHours(0, 0, 0, 0);
-    startDate.setHours(0, 0, 0, 0);
-
-    return startDate <= now;
+    return data.startDate <= todayStr;
   };
 
   // 인증하기 버튼 활성화 여부 결정

--- a/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
@@ -325,46 +325,33 @@ export const ChallengeProfileScreen: React.FC = () => {
       return;
     }
 
-    // 챌린지 일정 판단 (KST 기준)
-    const todayStr = getTodayYYYYMMDD_KST();
+    /**
+     * actionButtonStatus 우선 순위에 따른 처리
+     */
 
-    const isFull = data.currentParticipantCount >= data.maxParticipantCount;
-    const isAfterEnd = data.endDate < todayStr;
-    const hasStarted = data.startDate <= todayStr;
-
-    // actionButtonStatus에 따라 처리
-    if (data.actionButtonStatus === 'WAITLIST') {
-      Alert.alert('알림', '인원이 마감된 챌린지입니다.');
-      return;
-    }
-
+    // [1] DISABLED: 챌린지 종료
     if (data.actionButtonStatus === 'DISABLED') {
-      let alertMessage = '현재 참가할 수 없는 챌린지입니다.';
-
-      if (isAfterEnd) {
-        alertMessage = '이미 종료된 챌린지입니다.';
-      } else if (isFull) {
-        alertMessage = '인원이 마감된 챌린지입니다.';
-      } else if (hasStarted && !isAfterEnd) {
-        alertMessage = '라운드 진행 중에는 참가할 수 없습니다.';
-      } else {
-        alertMessage = '참가할 수 없는 챌린지입니다.';
-      }
-
-      Alert.alert('알림', alertMessage);
+      Alert.alert('알림', '이미 종료된 챌린지입니다.');
       return;
     }
 
-    if (data.actionButtonStatus !== 'JOIN') {
-      Alert.alert('알림', '지금은 참가할 수 없습니다.');
+    // [6] WAITLIST: 참가 전 + 정원 마감
+    if (data.actionButtonStatus === 'WAITLIST') {
+      Alert.alert('알림', '정원이 마감되어 대기자 신청만 가능합니다.');
       return;
     }
 
-    // 참가 가능한 경우 확인 모달 표시
-    setShowParticipateModal(true);
-    setIsPasswordMode(false);
-    setPassword('');
-    setPasswordError(undefined);
+    // [7] JOIN: 참가 전 + 모집 중
+    if (data.actionButtonStatus === 'JOIN') {
+      setShowParticipateModal(true);
+      setIsPasswordMode(false);
+      setPassword('');
+      setPasswordError(undefined);
+      return;
+    }
+
+    // 예외 케이스 (이미 참가 중인 경우 등 예상치 못한 상태인 경우 발생 시)
+    Alert.alert('알림', '현재는 참가 신청을 할 수 없습니다.');
   };
 
   // 참가하기 버튼 활성화 여부 결정
@@ -440,12 +427,8 @@ export const ChallengeProfileScreen: React.FC = () => {
       return true;
     }
 
-    const isStarted = isChallengeStarted();
-    const isDayValid = isTodayVerificationDay();
-    const isTimeValid = isNowVerificationTime();
-
-    // 챌린지가 시작하지 않았거나, 요일이 맞지 않거나, 시간이 맞지 않으면 비활성화
-    return !isStarted || !isDayValid || !isTimeValid;
+    // button status가 CERTIFY_AVAILABLE일 때만 활성화
+    return data.actionButtonStatus !== 'CERTIFY_AVAILABLE';
   };
 
   // 인증하기 버튼 클릭 핸들러
@@ -457,30 +440,62 @@ export const ChallengeProfileScreen: React.FC = () => {
 
     const isStarted = isChallengeStarted();
     const isDayValid = isTodayVerificationDay();
-    const isTimeValid = isNowVerificationTime();
 
-    // 비활성화 상태에서 클릭한 경우 알러트 표시
-    if (!isStarted) {
-      Alert.alert('알림', '라운드가 아직 시작되지 않았습니다.');
+    /**
+     * action button status 우선 순위에 따른 처리
+     */
+
+    // [1] DISABLED: 챌린지 종료
+    if (data.actionButtonStatus === 'DISABLED') {
+      Alert.alert('알림', '이미 종료된 챌린지입니다.');
       return;
     }
 
-    if (!isDayValid) {
-      Alert.alert('알림', '오늘은 인증 가능한 요일이 아닙니다.');
+    // [2, 3, 4] CERTIFIED: 백엔드가 CERTIFIED로 보내주는 경우 (상세 분기 필요)
+    if (data.actionButtonStatus === 'CERTIFIED') {
+      // [2] 라운드 시작 전 (오늘 < 시작일)
+      if (!isStarted) {
+        Alert.alert('알림', '라운드가 아직 시작되지 않았습니다.');
+        return;
+      }
+
+      // [3] 인증 요일이 아님
+      if (!isDayValid) {
+        Alert.alert('알림', '오늘은 인증 가능한 요일이 아닙니다.');
+        return;
+      }
+
+      // 오늘의 인증 완료 여부 확인을 위한 데이터 가공
+      const todayDayOfWeek = getDayOfWeek_KST();
+      const dayMap: { [key: number]: string } = {
+        0: 'SUNDAY', 1: 'MONDAY', 2: 'TUESDAY', 3: 'WEDNESDAY',
+        4: 'THURSDAY', 5: 'FRIDAY', 6: 'SATURDAY',
+      };
+      const todayDayName = dayMap[todayDayOfWeek];
+      const hasVerifiedToday = profile.verifiedDaysThisWeek?.includes(todayDayName) || false;
+
+      if (hasVerifiedToday) {
+        // [4] 인증 시간 내 + 이미 인증함
+        Alert.alert('알림', '오늘의 인증을 이미 완료했습니다.');
+      } else {
+        // [4] 인증 시간대가 아님 (인증 시간 내 + 미인증 상태가 아님)
+        Alert.alert('알림', '지금은 인증 가능한 시간대가 아닙니다.');
+      }
       return;
     }
 
-    if (!isTimeValid) {
-      Alert.alert('알림', '지금은 인증 가능한 시간대가 아닙니다.');
+    // [5] CERTIFY_AVAILABLE: 인증 시간 내 + 아직 인증 전
+    if (data.actionButtonStatus === 'CERTIFY_AVAILABLE') {
+      if (data.verificationType === 'PHOTO') {
+        navigation.navigate('ChallengeCertificationCamera', { challengeId });
+      } else if (data.verificationType === 'TEXT') {
+        navigation.navigate('ChallengeCertificationText', { challengeId });
+      }
       return;
     }
 
-    // 모든 조건을 만족하면 인증 타입에 따라 화면 이동
-    if (data.verificationType === 'PHOTO') {
-      navigation.navigate('ChallengeCertificationCamera', { challengeId });
-    } else if (data.verificationType === 'TEXT') {
-      navigation.navigate('ChallengeCertificationText', { challengeId });
-    }
+    // 예외 케이스
+    Alert.alert('알림', '현재는 인증을 진행할 수 없습니다.');
   };
 
   const handleParticipateConfirm = async () => {

--- a/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
@@ -428,11 +428,15 @@ export const ChallengeProfileScreen: React.FC = () => {
       return false;
     }
 
-    // startDate와 현재 날짜 비교
+    // 날짜만 비교 (타임존 이슈 방지)
     const now = new Date();
-    const startDate = new Date(data.startDate);
+    const [year, month, day] = data.startDate.split('-').map(Number);
+    const startDate = new Date(year, month - 1, day); // 로컬 타임존으로 파싱
 
-    // 시작일이 현재보다 이전이거나 같으면 시작된 것
+    // 시간 부분 제거하고 날짜만 비교
+    now.setHours(0, 0, 0, 0);
+    startDate.setHours(0, 0, 0, 0);
+
     return startDate <= now;
   };
 

--- a/src/screens/CreateChallenge/CreateChallengeQ2.tsx
+++ b/src/screens/CreateChallenge/CreateChallengeQ2.tsx
@@ -90,6 +90,7 @@ export const CreateChallengeQ2 = () => {
 
   // 모든 필드가 채워졌는지 확인
   const isNextEnabled =
+    thumbnailImage !== null &&
     challengeName.trim() !== '' &&
     oneLiner.trim() !== '' &&
     verificationMethod !== '' &&

--- a/src/screens/CreateChallenge/CreateChallengeQ2.tsx
+++ b/src/screens/CreateChallenge/CreateChallengeQ2.tsx
@@ -716,7 +716,7 @@ const styles = StyleSheet.create({
   selectionRight: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: scale(4),
+    gap: scale(12),
   },
   chevronContainer: {
     transform: [{ rotate: '0deg' }],

--- a/src/utils/kst.ts
+++ b/src/utils/kst.ts
@@ -11,9 +11,7 @@ const KST_OFFSET_MINUTES = 9 * 60;
  * 디바이스 시각을 KST로 보정하여 UTC 기반 Date 객체로 반환
  */
 export function getKstDateAsUtcBase(now: Date = new Date()): Date {
-  // 로컬 시각을 UTC로 변환 후 KST 오프셋(+9h) 적용
-  const utcMs = now.getTime() + now.getTimezoneOffset() * 60_000;
-  const kstMs = utcMs + KST_OFFSET_MINUTES * 60_000;
+  const kstMs = now.getTime() + KST_OFFSET_MINUTES * 60_000;
   return new Date(kstMs);
 }
 

--- a/src/utils/kst.ts
+++ b/src/utils/kst.ts
@@ -1,0 +1,45 @@
+/**
+ * KST(한국 표준시, UTC+9) 기준 시간 유틸리티
+ * 
+ * 디바이스의 로컬 타임존 설정과 관계없이 서비스 기준 시각(KST)을 정확히 계산
+ * 반환된 Date 객체는 반드시 'getUTC*' 메서드를 통해 읽어야 KST 값이 반환됨
+ */
+
+const KST_OFFSET_MINUTES = 9 * 60;
+
+/**
+ * 디바이스 시각을 KST로 보정하여 UTC 기반 Date 객체로 반환
+ */
+export function getKstDateAsUtcBase(now: Date = new Date()): Date {
+  // 로컬 시각을 UTC로 변환 후 KST 오프셋(+9h) 적용
+  const utcMs = now.getTime() + now.getTimezoneOffset() * 60_000;
+  const kstMs = utcMs + KST_OFFSET_MINUTES * 60_000;
+  return new Date(kstMs);
+}
+
+/**
+ * 현재 KST 날짜 반환 (YYYY-MM-DD)
+ */
+export function getTodayYYYYMMDD_KST(now: Date = new Date()): string {
+  const kst = getKstDateAsUtcBase(now);
+  const year = kst.getUTCFullYear();
+  const month = String(kst.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(kst.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * 현재 KST 요일 반환 (0: 일요일 ~ 6: 토요일)
+ */
+export function getDayOfWeek_KST(now: Date = new Date()): number {
+  const kst = getKstDateAsUtcBase(now);
+  return kst.getUTCDay();
+}
+
+/**
+ * 현재 KST 자정 이후 경과 시간(초) 반환
+ */
+export function getSecondsSinceMidnight_KST(now: Date = new Date()): number {
+  const kst = getKstDateAsUtcBase(now);
+  return kst.getUTCHours() * 3600 + kst.getUTCMinutes() * 60 + kst.getUTCSeconds();
+}


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
챌린지 개설 시 프로필 이미지를 업로드하지 않아도 다음 단계로 넘어가던 문제를 해결하기 위해 이미지 필드에 대한 검증 로직을 추가하고, 챌린지 시작일 비교 로직을 기존 UTC 기준에서 KST 기준으로 수정하여 날짜 오차가 발생하지 않도록 개선하였습니다

### 챌린지 프로필 Action Button 처리 로직 정리
#### 1. 챌린지 참가 관련 (`handleParticipate`)
| 우선순위 | 백엔드 Enum | 상세 조건 | 노출 메시지 / 동작 |
|:---:|:---:|:---|:---|
| 1 | `DISABLED` | (없음) | '이미 종료된 챌린지입니다.' |
| 6 | `WAITLIST` | 참가 전 + 정원 마감 | '정원이 마감되어 대기자 신청만 가능합니다.' |
| 7 | `JOIN` | 참가 전 + 모집 중 | 참가 확인 모달 오픈 |

#### 2. 챌린지 인증 관련 (`handleCertification`)
> 백엔드에서 `CERTIFIED` 상태를 여러 상황에서 공용으로 사용하고 있기 때문에 상세 분기 처리를 수행합니다

| 우선순위 | 백엔드 Enum | 상세 조건 | 노출 메시지 / 동작 |
|:---:|:---:|:---|:---|
| 1 | `DISABLED` | (없음) | '이미 종료된 챌린지입니다.' |
| 2 | `CERTIFIED` | 오늘 < 챌린지 시작일 | '라운드가 아직 시작되지 않았습니다.' |
| 3 | `CERTIFIED` | 오늘이 인증 요일이 아님 | '오늘은 인증 가능한 요일이 아닙니다.' |
| 4-1 | `CERTIFIED` | 인증 시간 내 + 이미 인증 완료 | '오늘의 인증을 이미 완료했습니다.' |
| 4-2 | `CERTIFIED` | 인증 시간대 아님 | '지금은 인증 가능한 시간대가 아닙니다.' |
| 5 | `CERTIFY_AVAILABLE` | 인증 시간 내 + 인증 전 | 인증 화면 이동 |

## 🔗 관련 이슈
close #49
<!-- 참고용: ref #이슈번호 -->

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [x] 새로운 기능
- [x] 버그 수정
- [x] UI/UX 개선
- [ ] 리팩토링
- [ ] 의존성 변경

## 📸 스크린샷
### iOS
| CERTIFY_AVAILABLE | CERTIFIED | CERTIFIED |
|---|---|---|
|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/8b9869ca-fc52-4dc7-9092-4068674df8de" />|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/f7d83e88-312a-4bdc-a33f-41e646b69444" />|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/5e4041dd-3cca-4bf4-80c8-64f21d7831ab" />|


## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
