### PR TITLE
[QA] 프로필 이미지 처리 및 챌린지 화면 UX 이슈 수정

### DIFF
--- a/src/components/challenge/CommentItem.tsx
+++ b/src/components/challenge/CommentItem.tsx
@@ -4,6 +4,7 @@ import { scale, verticalScale } from '../../utils/scaling';
 import { Text } from '../common/Text';
 import { colors } from '../../design/tokens';
 import { CommentItem as CommentItemType } from '../../libs/api/challenge';
+import { getS3ImageUrl } from '../../libs/s3';
 import DefaultProfileIcon from '../../../assets/icons/challenge-profile/default-profile.svg';
 import LikeUnselectedIcon from '../../../assets/icons/challenge-profile/like-unselected.svg';
 import LikeSelectedIcon from '../../../assets/icons/challenge-profile/like-selected.svg';
@@ -133,9 +134,9 @@ export const CommentItem: React.FC<CommentItemProps> = ({
       {/* 프로필 이미지 - 삭제/탈퇴는 숨김 */}
       {showProfile && (
         <View style={styles.profileContainer}>
-          {comment.userProfileUrl ? (
+          {getS3ImageUrl(comment.userProfileUrl) ? (
             <Image
-              source={{ uri: comment.userProfileUrl.replace('http://', 'https://') }}
+              source={{ uri: getS3ImageUrl(comment.userProfileUrl)! }}
               style={styles.profileImage}
             />
           ) : (

--- a/src/components/challenge/CommentItem.tsx
+++ b/src/components/challenge/CommentItem.tsx
@@ -149,7 +149,7 @@ export const CommentItem: React.FC<CommentItemProps> = ({
       <View style={[styles.contentContainer, !showProfile && styles.contentContainerNoProfile]}>
         {isBlocked ? (
           /* 차단된 사용자 - userName 없이 content만 표시 */
-          <Text variant="xsReg" color={colors.text.tertiary} style={styles.commentText}>
+          <Text variant="xsReg" color={colors.text.secondary} style={styles.commentText}>
             {comment.content}
           </Text>
         ) : (

--- a/src/libs/s3.ts
+++ b/src/libs/s3.ts
@@ -33,12 +33,12 @@ try {
  */
 export const getS3ImageUrl = (imageKey: string | null | undefined): string | null => {
   if (!imageKey) return null;
-  
-  // 이미 URL인 경우 그대로 반환
+
+  // 이미 URL인 경우 http를 https로 변환하여 반환
   if (imageKey.startsWith('http://') || imageKey.startsWith('https://')) {
-    return imageKey;
+    return imageKey.replace('http://', 'https://');
   }
-  
+
   // S3 키를 URL로 변환
   return `${S3_BASE_URL}/${imageKey}`;
 };

--- a/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationDetailScreen.tsx
@@ -31,6 +31,7 @@ import {
   reportUser,
   ReportReason
 } from '../../libs/api/challenge';
+import { getS3ImageUrl } from '../../libs/s3';
 import MoreIcon from '../../../assets/icons/more.svg';
 import DefaultProfileIcon from '../../../assets/icons/challenge-profile/default-profile.svg';
 import LikeSelectedIcon from '../../../assets/icons/challenge-profile/like-selected.svg';
@@ -616,9 +617,9 @@ export const ChallengeCertificationDetailScreen: React.FC = () => {
         {/* 사용자 정보 */}
         <View style={styles.userSection}>
           <View style={styles.userAvatar}>
-            {verification.user.profileImageUrl ? (
+            {getS3ImageUrl(verification.user.profileImageUrl) ? (
               <Image
-                source={{ uri: verification.user.profileImageUrl.replace('http://', 'https://') }}
+                source={{ uri: getS3ImageUrl(verification.user.profileImageUrl)! }}
                 style={styles.profileImage}
               />
             ) : (

--- a/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
@@ -187,6 +187,37 @@ export const ChallengeProfileScreen: React.FC = () => {
     }
   };
 
+  // 전체 데이터 새로고침 함수
+  const refreshAllData = async () => {
+    try {
+      // 챌린지 기본 정보 조회
+      const detailResult = await getChallengeDetail(challengeId);
+      setData(detailResult);
+      setIsLiked(detailResult.isLiked);
+      setIsParticipated(detailResult.isParticipant);
+
+      // 챌린지 프로필 정보 조회
+      try {
+        const profileResult = await getChallengeProfile(challengeId);
+        processProfileData(profileResult);
+      } catch (profileError: any) {
+        setProfile(null);
+      }
+
+      // 관찰자 모드이거나 참가한 경우 인증현황 데이터 조회
+      if (detailResult.isObserverMode || detailResult.isParticipant) {
+        await fetchRoundsAndStats();
+
+        // 선택된 라운드가 있으면 피드도 새로고침
+        if (selectedRound !== null) {
+          await fetchVerificationFeed(selectedRound);
+        }
+      }
+    } catch (error: any) {
+      console.error('데이터 새로고침 실패:', error);
+    }
+  };
+
   // 화면 포커스 시마다 데이터 새로고침
   useFocusEffect(
     useCallback(() => {
@@ -515,13 +546,8 @@ export const ChallengeProfileScreen: React.FC = () => {
         setPasswordError(undefined);
         setIsParticipated(true);
 
-        // 참가 후 프로필 정보 다시 불러오기
-        try {
-          const profileResult = await getChallengeProfile(challengeId);
-          processProfileData(profileResult);
-        } catch (profileError) {
-          // 프로필 조회 실패 시 무시
-        }
+        // 참가 후 전체 데이터 새로고침 (버튼 상태 업데이트를 위함)
+        await refreshAllData();
 
         Alert.alert('완료', '챌린지에 참가했습니다.');
       } else {
@@ -530,13 +556,8 @@ export const ChallengeProfileScreen: React.FC = () => {
         setShowParticipateModal(false);
         setIsParticipated(true);
 
-        // 참가 후 프로필 정보 다시 불러오기
-        try {
-          const profileResult = await getChallengeProfile(challengeId);
-          processProfileData(profileResult);
-        } catch (profileError) {
-          console.warn('프로필 정보 조회 실패:', profileError);
-        }
+        // 참가 후 전체 데이터 새로고침 (버튼 상태 업데이트를 위함)
+        await refreshAllData();
 
         Alert.alert('완료', '챌린지에 참가했습니다.');
       }


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
- `getS3ImageUrl` 기준으로 프로필 이미지 URL 처리 방식 통합 (http -> https 포함)
- 차단된 사용자 댓글 텍스트 색상 통일
- 챌린지 참가 이후 화면 상태가 즉시 반영되지 않던 문제 해결

## 🔗 관련 이슈
close #51
<!-- 참고용: ref #이슈번호 -->

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [ ] 새로운 기능
- [x] 버그 수정
- [x] UI/UX 개선
- [ ] 리팩토링
- [ ] 의존성 변경

## 📸 스크린샷
| 기능 | 이미지 |
|---|---|
|   |   |

## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
