### PR TITLE
[FIX] Android 하단 시스템 네비게이션바 영역 SafeArea 적용

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,7 @@
 import { StatusBar, StyleSheet, useColorScheme, View, AppState, DeviceEventEmitter } from 'react-native';
 import {
   SafeAreaProvider,
+  SafeAreaView,
 } from 'react-native-safe-area-context';
 import React, { useEffect, useState, useRef } from 'react';
 import BootSplash from 'react-native-bootsplash';
@@ -30,8 +31,10 @@ function App() {
   return (
     <SafeAreaProvider>
       <GestureHandlerRootView style={{ flex: 1 }}>
-        <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
-        <AppContent />
+        <SafeAreaView style={{ flex: 1 }} edges={['bottom']}>
+          <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
+          <AppContent />
+        </SafeAreaView>
       </GestureHandlerRootView>
     </SafeAreaProvider>
   );


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
안드로이드 기기에서 하단 시스템 네비게이션바에 콘텐츠 영역이 가려지던 문제를 해결했습니다
`App.tsx`에 `SafeAreaProvider`는 적용되어 있었으나 `SafeAreaView`를 적용하지 않았던 점이 원인이었고,
`edges={['bottom']}` 옵션을 적용하여 하단 Safe Area를 전역으로 처리하였습니다


## 🔗 관련 이슈
close #54
<!-- 참고용: ref #이슈번호 -->

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [ ] 새로운 기능
- [x] 버그 수정
- [ ] UI/UX 개선
- [ ] 리팩토링
- [ ] 의존성 변경

## 📸 스크린샷
| 로그인 | 챌린지 추천 온보딩 | 챌린지 프로필 |
|---|---|---|
|<img width="300" height="2400" alt="image" src="https://github.com/user-attachments/assets/7e518215-42bd-4192-8937-f7c524978d20" />|<img width="300" height="2400" alt="image" src="https://github.com/user-attachments/assets/0da2f76c-0221-423f-b303-ea326514b0dd" />|<img width="300" height="2400" alt="image" src="https://github.com/user-attachments/assets/ec6fe918-c994-4221-acbd-f3768b96b834" />|
## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
- Android 실기기에서 하단 여백 높이 조정이 필요한 경우 베타테스트 진행하면서 차차 수정하겠습니다