### PR TITLE
[FEAT] 챌린지 공유 기능 구현

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,6 +33,13 @@
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
+      <!-- Deep Link Scheme -->
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="hrr" />
+      </intent-filter>
     </activity>
     
     <!-- 카카오 로그인 Redirect URI 처리 -->

--- a/ios/HrrApp/Info.plist
+++ b/ios/HrrApp/Info.plist
@@ -77,6 +77,16 @@
 				<string>com.umc.hrrapp</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>hrr</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>hrr</string>
+			</array>
+		</dict>
 	</array>
 	<key>KAKAO_APP_KEY</key>
 	<string>b06209dc6556d7eb3e91a03887487d56</string>

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -46,6 +46,27 @@ import CustomTabBar from '../components/common/CustomTabBar';
 const Tab = createBottomTabNavigator<HomeTabParamList>();
 const Stack = createStackNavigator<RootStackParamList>();
 
+// Deep Link 설정
+// TODO: 도메인 배포 후 prefixes에 도메인 추가
+const linking = {
+  prefixes: ['hrr://'],
+  config: {
+    screens: {
+      HomeTabs: 'home',
+      ChallengeProfile: 'challenge/:challengeId',
+      User: 'user/:userId',
+      ChallengeCertificationDetail: 'verification/:verificationId',
+      Notifications: 'notifications',
+      ChallengeList: 'challenges',
+      PopularChallenge: 'popular',
+      ParticipatingChallenge: 'participating',
+      CertificationHistory: 'history',
+      LikedChallenge: 'liked',
+      CompletedChallenge: 'completed',
+    },
+  },
+};
+
 const OnboardingScreenWrapper = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
 
@@ -85,6 +106,7 @@ const HomeTabs = () => (
 const RootNavigator = ({ showRecommendation = false }: { showRecommendation?: boolean }) => (
   <CreateChallengeProvider>
     <NavigationContainer
+      linking={linking}
       onReady={() => {
         // 네비가 준비되면 스플래시를 숨김
         RNBootSplash.hide({ fade: true });

--- a/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
@@ -11,6 +11,7 @@ import {
   Dimensions,
   ActivityIndicator,
   Alert,
+  Share,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp, useFocusEffect } from '@react-navigation/native';
@@ -320,8 +321,24 @@ export const ChallengeProfileScreen: React.FC = () => {
     rules: profile?.rule || '',
   };
 
-  const handleShare = () => {
-    // TODO: 공유 기능 구현
+  const handleShare = async () => {
+    try {
+      const shareMessage =
+        `🔥 ${data.title} 챌린지에 참여해요!
+       
+        현재 ${data.currentParticipantCount}명이 함께 도전 중이에요.
+        혼자보다는 같이, 흐르르에서 끝까지 목표를 달성해 보세요 💪`;
+
+      await Share.share({
+        message: shareMessage,
+        title: `${data.title} 챌린지에 참여해요!`,
+      });
+    } catch (error: any) {
+      // 사용자가 공유를 취소한 경우는 에러로 처리하지 않음
+      if (error.message !== 'User did not share') {
+        Alert.alert('오류', '공유하기에 실패했습니다.');
+      }
+    }
   };
 
   const handleLike = async () => {

--- a/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
@@ -323,12 +323,15 @@ export const ChallengeProfileScreen: React.FC = () => {
 
   const handleShare = async () => {
     try {
-      const shareMessage =
-        `🔥 ${data.title} 챌린지에 참여해요!
-       
-        현재 ${data.currentParticipantCount}명이 함께 도전 중이에요.
-        혼자보다는 같이, 흐르르에서 끝까지 목표를 달성해 보세요 💪`;
+      const deepLink = `hrr://challenge/${challengeId}`;
+      const shareMessage = 
+`🔥 ${data.title} 챌린지에 참여해요!
 
+현재 ${data.currentParticipantCount}명이 함께 도전 중이에요.
+혼자보다는 같이, 흐르르에서 끝까지 목표를 달성해 보세요 💪
+
+${deepLink}`;
+      
       await Share.share({
         message: shareMessage,
         title: `${data.title} 챌린지에 참여해요!`,


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
챌린지 프로필에서 공유하기 버튼을 눌렀을 때 실제로 공유가 가능하도록 기능을 구현했습니다.

## 🔗 관련 이슈
close #53
<!-- 참고용: ref #이슈번호 -->

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [x] 새로운 기능
- [ ] 버그 수정
- [ ] UI/UX 개선
- [ ] 리팩토링
- [ ] 의존성 변경

## 📸 스크린샷
### iOS
| Activity View | 카카오톡 전송 |
|---|---|
|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/d1414b93-bca6-4232-9ad1-da59e44f2448" />|<img width="400" height="902" alt="image" src="https://github.com/user-attachments/assets/a8517906-68f2-48ff-bd3b-e68e59abed65" />|

## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
- 현재 공유 기능은 커스텀 딥링크(`hrr://`) 기반으로, 어플이 설치된 사용자 간의 공유 기능만 지원합니다. 앱 미설치 시 앱 설치 페이지로 리다이렉트/랜딩 페이지 처리 등은 후속 작업으로 진행 예정입니다