### PR TITLE
[FIX] Android 타임스탬프 배경 블러 렌더링 이슈 대응

### DIFF
--- a/src/screens/ChallengeProfile/ChallengeCertificationCameraScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationCameraScreen.tsx
@@ -290,12 +290,37 @@ export const ChallengeCertificationCameraScreen: React.FC = () => {
                     right: scale(16),
                   }
                 ]}>
-                  <BlurView
-                    style={StyleSheet.absoluteFill}
-                    blurType="light"
-                    blurAmount={20}
-                    reducedTransparencyFallbackColor="black"
-                  />
+                  {Platform.OS === 'ios' ? (
+                    <BlurView
+                      style={StyleSheet.absoluteFill}
+                      blurType="light"
+                      blurAmount={20}
+                      reducedTransparencyFallbackColor="black"
+                    />
+                  ) : (
+                    <>
+                      {/* 어두운 블러 효과 시뮬레이션 레이어 */}
+                      <View
+                        style={[
+                          StyleSheet.absoluteFill,
+                          {
+                            backgroundColor: 'rgba(0, 0, 0, 0.05)',
+                            borderRadius: scale(10),
+                          },
+                        ]}
+                      />
+                      {/* 밝은 블러 효과 시뮬레이션 레이어 */}
+                      <View
+                        style={[
+                          StyleSheet.absoluteFill,
+                          {
+                            backgroundColor: 'rgba(255, 255, 255, 0.2)',
+                            borderRadius: scale(10),
+                          },
+                        ]}
+                      />
+                    </>
+                  )}
                   <Text variant="xsReg" color={colors.white} style={styles.timestampText}>
                     {formatTimestamp(imageTimestamp)}
                   </Text>
@@ -331,12 +356,37 @@ export const ChallengeCertificationCameraScreen: React.FC = () => {
                     right: scale(16),
                   }
                 ]}>
-                  <BlurView
-                    style={StyleSheet.absoluteFill}
-                    blurType="light"
-                    blurAmount={20}
-                    reducedTransparencyFallbackColor="black"
-                  />
+                  {Platform.OS === 'ios' ? (
+                    <BlurView
+                      style={StyleSheet.absoluteFill}
+                      blurType="light"
+                      blurAmount={20}
+                      reducedTransparencyFallbackColor="black"
+                    />
+                  ) : (
+                    <>
+                      {/* 배경을 약간 어둡게 하는 레이어 (블러의 어두운 부분 시뮬레이션) */}
+                      <View
+                        style={[
+                          StyleSheet.absoluteFill,
+                          {
+                            backgroundColor: 'rgba(0, 0, 0, 0.25)',
+                            borderRadius: scale(10),
+                          },
+                        ]}
+                      />
+                      {/* 밝은 블러 효과 시뮬레이션 레이어 */}
+                      <View
+                        style={[
+                          StyleSheet.absoluteFill,
+                          {
+                            backgroundColor: 'rgba(255, 255, 255, 0.2)',
+                            borderRadius: scale(10),
+                          },
+                        ]}
+                      />
+                    </>
+                  )}
                   <Text variant="xsReg" color={colors.white} style={styles.timestampText}>
                     {formatTimestamp(imageTimestamp)}
                   </Text>
@@ -423,14 +473,21 @@ const styles = StyleSheet.create({
     right: scale(16),
     width: scale(137),
     height: verticalScale(32),
-    backgroundColor: 'rgba(0, 0, 0, 0.2)',
+    backgroundColor: Platform.OS === 'ios' ? 'rgba(0, 0, 0, 0.2)' : 'transparent',
     borderRadius: scale(10),
     justifyContent: 'center',
     alignItems: 'center',
     overflow: 'hidden',
   },
+  androidBlurOverlay: {
+    backgroundColor: 'rgba(0, 0, 0, 0.35)',
+    borderRadius: scale(10),
+  },
   timestampText: {
     color: colors.white,
+    textShadowColor: 'rgba(0, 0, 0, 0.5)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
   },
   certificationButtonContainer: {
     width: '100%',

--- a/src/screens/ChallengeProfile/ChallengeCertificationCameraScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeCertificationCameraScreen.tsx
@@ -32,7 +32,20 @@ export const ChallengeCertificationCameraScreen: React.FC = () => {
   const [isImageLoaded, setIsImageLoaded] = useState(false);
   const viewShotRef = useRef<ViewShot>(null);
 
-  const CROP_SIZE = 350;
+  // 화면에 보이는 프리뷰 크기
+  const PREVIEW_SIZE = 350;
+  // 실제 캡처되는 고해상도 이미지 크기
+  const CAPTURE_SIZE = 1080;
+  // 캡처용 배율
+  const CAPTURE_SCALE = CAPTURE_SIZE / PREVIEW_SIZE;
+
+  // 프리뷰 기준 타임스탬프 값들
+  const TS_WIDTH = scale(137);
+  const TS_HEIGHT = verticalScale(32);
+  const TS_RADIUS = scale(10);
+  const TS_BOTTOM = verticalScale(16);
+  const TS_RIGHT = scale(16);
+  const TS_FONT = 12;
 
   useEffect(() => {
     handleImagePicker();
@@ -238,7 +251,7 @@ export const ChallengeCertificationCameraScreen: React.FC = () => {
   // 이미지가 선택된 경우 인증 화면 표시
   if (selectedImage && imageSize) {
     const screenWidth = Dimensions.get('window').width - 40;
-    const displaySize = Math.min(screenWidth, CROP_SIZE);
+    const displaySize = Math.min(screenWidth, PREVIEW_SIZE);
 
     return (
       <SafeAreaView style={styles.certificationContainer}>
@@ -251,16 +264,16 @@ export const ChallengeCertificationCameraScreen: React.FC = () => {
               style={[
                 styles.hiddenViewShot,
                 {
-                  width: CROP_SIZE,
-                  height: CROP_SIZE,
+                  width: CAPTURE_SIZE,
+                  height: CAPTURE_SIZE,
                 }
               ]}
               options={{
                 format: 'jpg',
                 quality: 1.0,
                 result: 'tmpfile',
-                width: CROP_SIZE,
-                height: CROP_SIZE,
+                width: CAPTURE_SIZE,
+                height: CAPTURE_SIZE,
                 snapshotContentContainer: false,
               }}
             >
@@ -269,8 +282,8 @@ export const ChallengeCertificationCameraScreen: React.FC = () => {
                 style={[
                   styles.thumbnailImage,
                   {
-                    width: CROP_SIZE,
-                    height: CROP_SIZE,
+                    width: CAPTURE_SIZE,
+                    height: CAPTURE_SIZE,
                   }
                 ]}
                 resizeMode="cover"
@@ -281,15 +294,22 @@ export const ChallengeCertificationCameraScreen: React.FC = () => {
                   // 일부 URI에서 onError 발생 가능. 캡처/업로드 단계에서 재검증
                 }}
               />
-              {/* 타임스탬프 오버레이 */}
+              {/* 타임스탬프 오버레이 - 캡처용 */}
               {imageTimestamp && (
-                <View style={[
-                  styles.timestampContainer,
-                  {
-                    bottom: verticalScale(16),
-                    right: scale(16),
-                  }
-                ]}>
+                <View
+                  style={{
+                    position: 'absolute',
+                    bottom: TS_BOTTOM * CAPTURE_SCALE,
+                    right: TS_RIGHT * CAPTURE_SCALE,
+                    width: TS_WIDTH * CAPTURE_SCALE,
+                    height: TS_HEIGHT * CAPTURE_SCALE,
+                    borderRadius: TS_RADIUS * CAPTURE_SCALE,
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    overflow: 'hidden',
+                    backgroundColor: Platform.OS === 'ios' ? 'rgba(0, 0, 0, 0.2)' : 'transparent',
+                  }}
+                >
                   {Platform.OS === 'ios' ? (
                     <BlurView
                       style={StyleSheet.absoluteFill}
@@ -304,8 +324,8 @@ export const ChallengeCertificationCameraScreen: React.FC = () => {
                         style={[
                           StyleSheet.absoluteFill,
                           {
-                            backgroundColor: 'rgba(0, 0, 0, 0.05)',
-                            borderRadius: scale(10),
+                            backgroundColor: 'rgba(0, 0, 0, 0.25)',
+                            borderRadius: TS_RADIUS * CAPTURE_SCALE,
                           },
                         ]}
                       />
@@ -315,13 +335,20 @@ export const ChallengeCertificationCameraScreen: React.FC = () => {
                           StyleSheet.absoluteFill,
                           {
                             backgroundColor: 'rgba(255, 255, 255, 0.2)',
-                            borderRadius: scale(10),
+                            borderRadius: TS_RADIUS * CAPTURE_SCALE,
                           },
                         ]}
                       />
                     </>
                   )}
-                  <Text variant="xsReg" color={colors.white} style={styles.timestampText}>
+                  <Text
+                    style={{
+                      color: colors.white,
+                      fontSize: TS_FONT * CAPTURE_SCALE,
+                      lineHeight: TS_FONT * CAPTURE_SCALE * 1.2,
+                      fontFamily: 'Pretendard-Regular',
+                    }}
+                  >
                     {formatTimestamp(imageTimestamp)}
                   </Text>
                 </View>
@@ -473,21 +500,14 @@ const styles = StyleSheet.create({
     right: scale(16),
     width: scale(137),
     height: verticalScale(32),
-    backgroundColor: Platform.OS === 'ios' ? 'rgba(0, 0, 0, 0.2)' : 'transparent',
+    backgroundColor: 'rgba(0, 0, 0, 0.2)',
     borderRadius: scale(10),
     justifyContent: 'center',
     alignItems: 'center',
     overflow: 'hidden',
   },
-  androidBlurOverlay: {
-    backgroundColor: 'rgba(0, 0, 0, 0.35)',
-    borderRadius: scale(10),
-  },
   timestampText: {
     color: colors.white,
-    textShadowColor: 'rgba(0, 0, 0, 0.5)',
-    textShadowOffset: { width: 0, height: 1 },
-    textShadowRadius: 2,
   },
   certificationButtonContainer: {
     width: '100%',

--- a/src/screens/RandomMissionScreen.tsx
+++ b/src/screens/RandomMissionScreen.tsx
@@ -227,12 +227,37 @@ const RandomMissionScreen = () => {
             {/* 타임스탬프 오버레이 */}
             {imageTimestamp && (
               <View style={styles.timestampContainer}>
-                <BlurView
-                  style={StyleSheet.absoluteFill}
-                  blurType="light"
-                  blurAmount={20}
-                  reducedTransparencyFallbackColor="black"
-                />
+                {Platform.OS === 'ios' ? (
+                  <BlurView
+                    style={StyleSheet.absoluteFill}
+                    blurType="light"
+                    blurAmount={20}
+                    reducedTransparencyFallbackColor="black"
+                  />
+                ) : (
+                  <>
+                    {/* 어두운 블러 효과 시뮬레이션 레이어 */}
+                    <View
+                      style={[
+                        StyleSheet.absoluteFill,
+                        {
+                          backgroundColor: 'rgba(0, 0, 0, 0.05)',
+                          borderRadius: scale(10),
+                        },
+                      ]}
+                    />
+                    {/* 밝은 블러 효과 시뮬레이션 레이어 */}
+                    <View
+                      style={[
+                        StyleSheet.absoluteFill,
+                        {
+                          backgroundColor: 'rgba(255, 255, 255, 0.2)',
+                          borderRadius: scale(10),
+                        },
+                      ]}
+                    />
+                  </>
+                )}
                 <Text variant="xsReg" color={colors.white} style={styles.timestampText}>
                   {formatTimestamp(imageTimestamp)}
                 </Text>
@@ -455,14 +480,21 @@ const styles = StyleSheet.create({
     right: scale(16),
     width: scale(137),
     height: verticalScale(32),
-    backgroundColor: 'rgba(0, 0, 0, 0.2)',
+    backgroundColor: Platform.OS === 'ios' ? 'rgba(0, 0, 0, 0.2)' : 'transparent',
     borderRadius: scale(10),
     justifyContent: 'center',
     alignItems: 'center',
     overflow: 'hidden',
   },
+  androidBlurOverlay: {
+    backgroundColor: 'rgba(0, 0, 0, 0.35)',
+    borderRadius: scale(10),
+  },
   timestampText: {
     color: colors.white,
+    textShadowColor: 'rgba(0, 0, 0, 0.5)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
   },
   certificationButtonContainer: {
     width: '100%',

--- a/src/screens/RandomMissionScreen.tsx
+++ b/src/screens/RandomMissionScreen.tsx
@@ -241,7 +241,7 @@ const RandomMissionScreen = () => {
                       style={[
                         StyleSheet.absoluteFill,
                         {
-                          backgroundColor: 'rgba(0, 0, 0, 0.05)',
+                          backgroundColor: 'rgba(0, 0, 0, 0.25)',
                           borderRadius: scale(10),
                         },
                       ]}
@@ -480,21 +480,14 @@ const styles = StyleSheet.create({
     right: scale(16),
     width: scale(137),
     height: verticalScale(32),
-    backgroundColor: Platform.OS === 'ios' ? 'rgba(0, 0, 0, 0.2)' : 'transparent',
+    backgroundColor: 'rgba(0, 0, 0, 0.2)',
     borderRadius: scale(10),
     justifyContent: 'center',
     alignItems: 'center',
     overflow: 'hidden',
   },
-  androidBlurOverlay: {
-    backgroundColor: 'rgba(0, 0, 0, 0.35)',
-    borderRadius: scale(10),
-  },
   timestampText: {
     color: colors.white,
-    textShadowColor: 'rgba(0, 0, 0, 0.5)',
-    textShadowOffset: { width: 0, height: 1 },
-    textShadowRadius: 2,
   },
   certificationButtonContainer: {
     width: '100%',


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
Android 일부 기기에서 `BlurView` 사용 시 ViewShot 캡처 결과가 하얗게 렌더링되는 문제가 발생하여 플랫폼별 처리 방식을 분리했습니다.
iOS는 기존 `BlurView` 방식을 유지하고, Android는 `BlurView` 제거 후 단색의 반투명 배경으로 대체하였습니다

## 🔗 관련 이슈
close #58
<!-- 참고용: ref #이슈번호 -->

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [ ] 새로운 기능
- [x] 버그 수정
- [ ] UI/UX 개선
- [ ] 리팩토링
- [ ] 의존성 변경

## 📸 스크린샷
| 촬영 후 프리뷰 | 사진이 첨부된 본문 |
|---|---|
|<img width="300" height="2400" alt="image" src="https://github.com/user-attachments/assets/f5c78d27-069e-4772-8344-ab062c9c5e83" />|<img width="300" height="2400" alt="image" src="https://github.com/user-attachments/assets/e8e69da2-dcd0-4c0b-975d-dd429e8bdc0d" />|

## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
- `RandomMissionScreen`에서는 ViewShot을 사용하지 않으며, 원본 이미지 그대로 S3에 업로드하고 있습니다. 랜덤 미션 인증 시 시간 정보(`updated_at`)가 함께 API로 전송되어 서버 DB에서 확인이 가능할 것이라고 생각해 업로드 이미지에 타임스탬프가 포함되지 않은 방식으로 구현되어있습니다. 추후 백엔드와 협의 후, 필요할 경우 타임스탬프가 포함된 이미지 업로드 방식으로 기능을 확장하는 방향으로 작업하겠습니다