### PR TITLE
[FIX] 앱 다크모드 비활성화

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import { StatusBar, useColorScheme, AppState, DeviceEventEmitter, Platform, Linking } from 'react-native';
+import { StatusBar, AppState, DeviceEventEmitter, Platform, Linking } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import React, { useEffect, useState, useRef } from 'react';
 import BootSplash from 'react-native-bootsplash';
@@ -17,8 +17,6 @@ function getQueryParam(url: string, param: string): string | null {
 }
 
 function App() {
-  const isDarkMode = useColorScheme() === 'dark';
-
   useEffect(() => {
     // 앱 초기화 작업
     const init = async () => {
@@ -102,7 +100,7 @@ function App() {
           style={{ flex: 1 }}
           edges={Platform.OS === 'android' ? ['bottom'] : []}
         >
-          <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
+          <StatusBar barStyle="dark-content" backgroundColor="transparent" translucent />
           <AppContent />
         </SafeAreaView>
       </GestureHandlerRootView>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,8 @@
 <resources>
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
-        <!-- Customize your theme here. -->
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
+        <!-- 다크모드 해제 -->
+        <item name="android:forceDarkAllowed">false</item>
     </style>
 
     <style name="BootTheme" parent="Theme.BootSplash">

--- a/ios/HrrApp/Info.plist
+++ b/ios/HrrApp/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
핸드폰 시스템 설정에서 다크모드를 설정할 경우, status bar 텍스트가 하얗게 보이지 않는 버그를 수정하였습니다
현재 우리 앱은 다크모드를 지원하지 않기 때문에, 다크모드 대응 대신 앱 전체에서 라이트모드를 고정하는 방향으로 결정하였습니다

## 🔗 관련 이슈
close #77 
<!-- 참고용: ref #이슈번호 -->

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [ ] 새로운 기능
- [x] 버그 수정
- [ ] UI/UX 개선
- [ ] 리팩토링
- [ ] 의존성 변경

## 📸 스크린샷
### iOS
| 다크모드(수정 전) | 다크모드(수정 후) |
|---|---|
|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/305291c5-932c-4929-b658-b79ca3f30d94" />|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/b79847ed-1e72-4a5c-afbc-22ffac3cc9ac" />|

### Android
| 다크모드(수정 전) | 다크모드(수정 후) |
|---|---|
|<img width="300" height="2400" alt="image" src="https://github.com/user-attachments/assets/9e9e8cea-dbdb-4128-aaf1-5eeea0cc3861" />|<img width="300" height="2400" alt="image" src="https://github.com/user-attachments/assets/dd165d8c-54f5-43a3-81a3-c7aca374bb1e" />|

## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
