### PR TITLE
[FEAT] 챌린지 프로필 기간 표시 및 프로필 문구 분기 처리

### DIFF
--- a/src/components/MyPage/ParticipatingChallengeSection.tsx
+++ b/src/components/MyPage/ParticipatingChallengeSection.tsx
@@ -6,7 +6,7 @@ import {
   FlatList,
   ListRenderItemInfo,
 } from 'react-native';
-import { colors, radius, spacing, typography } from '../../design/tokens';
+import { colors, radius, spacing } from '../../design/tokens';
 import { Text } from '../common/Text';
 import ComponentHeader from '../common/ComponentHeader';
 import PlusIcon from '../../../assets/icons/plus.svg';
@@ -34,16 +34,28 @@ const ParticipatingChallengeSection = ({
     return <ChallengeCard item={item} onPress={onPressItem} />;
   };
 
-  const renderEmptyState = () => (
-    <TouchableOpacity style={styles.emptyCard} onPress={onPressEmpty} activeOpacity={0.8}>
-      <View style={styles.emptyContent}>
-        <PlusIcon width={scale(20)} height={scale(20)} fill={colors.text.secondary} />
-        <Text variant="xsReg" color={colors.text.secondary}>
-          새로운 챌린지에 가입해 보세요
+  const renderEmptyState = () => {
+    if (onPressEmpty) {
+      return (
+        <TouchableOpacity style={styles.emptyCard} onPress={onPressEmpty} activeOpacity={0.8}>
+          <View style={styles.emptyContent}>
+            <PlusIcon width={scale(20)} height={scale(20)} fill={colors.text.tertiary} />
+            <Text variant="xsReg" color={colors.text.tertiary}>
+              새로운 챌린지에 가입해 보세요
+            </Text>
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    return (
+      <View style={styles.emptyCard}>
+        <Text variant="xsReg" color={colors.text.tertiary}>
+          아직 참가중인 챌린지가 없어요!
         </Text>
       </View>
-    </TouchableOpacity>
-  );
+    );
+  };
 
   return (
     <View>
@@ -78,14 +90,9 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-
   emptyContent: {
     alignItems: 'center',
     gap: spacing.sm,
-  },
-
-  emptyText: {
-    color: colors.text.secondary,
   },
 });
 

--- a/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
+++ b/src/screens/ChallengeProfile/ChallengeProfileScreen.tsx
@@ -949,6 +949,13 @@ ${deepLink}`;
             {isParticipated ? (
               // 참가 후 UI
               <>
+                {/* 챌린지 기간 */}
+                <View style={[styles.challengePeriodSection, { paddingTop: verticalScale(28) }]}>
+                  <Text variant="smReg" color={colors.text.primary}>
+                    {formatChallengePeriod()}
+                  </Text>
+                </View>
+
                 {/* 요일별 인증 상태 */}
                 <View style={styles.daySelectionSection}>
                   {['일', '월', '화', '수', '목', '금', '토'].map((day) => {
@@ -1034,7 +1041,7 @@ ${deepLink}`;
               <>
                 {/* 챌린지 기간 */}
                 <View style={styles.challengePeriodSection}>
-                  <Text variant="xsReg" color={colors.text.primary}>
+                  <Text variant="smReg" color={colors.text.primary}>
                     {formatChallengePeriod()}
                   </Text>
                 </View>
@@ -1383,7 +1390,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     paddingHorizontal: scale(20),
-    paddingTop: verticalScale(28),
+    paddingTop: verticalScale(20),
   },
   dayButton: {
     width: scale(44),


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
- 챌린지 프로필에서 참가 여부와 무관하게 라운드 기간 상시 표시 (기존에는 챌린지 참가 전에만 표시되었음 #69)
- 다른 유저 프로필에서 참가 중인 챌린지가 없을 경우 문구 분기 처리 (`새로운 챌린지에 가입해 보세요` -> `아직 참가중인 챌린지가 없어요!`)


## 🔗 관련 이슈
close #84 
ref #79

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [x] 새로운 기능
- [ ] 버그 수정
- [x] UI/UX 개선
- [ ] 리팩토링
- [ ] 의존성 변경

## 📸 스크린샷
| 챌린지 참가 전 | 챌린지 참가 후 | 마이 프로필 | 다른 유저 프로필 |
|---|---|---|---|
|<img width="300" height="1311" alt="image" src="https://github.com/user-attachments/assets/c4419093-4cf1-41c3-8e40-f909db674c9a" />|<img width="300" height="1311" alt="image" src="https://github.com/user-attachments/assets/0d99db91-35a6-48d4-b6f1-2c4ea5a0c07c" />|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/b6e8b06a-a175-4656-be37-a554475d20f2" />|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/27cba5ad-1dcb-4c43-96b3-6c84cc640c61" />|





## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
