### PR TITLE
[FIX] Xcode Cloud 빌드 정상화 (ci_post_clone.sh 절대경로 수정)

### DIFF
--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # 프로젝트 루트로 이동
-cd ../..
+# cd ../..
 
 # Node.js 설치
 brew install node
@@ -10,8 +10,9 @@ brew install node
 brew install cocoapods
 
 # Node 패키지 설치
+cd "$CI_PRIMARY_REPOSITORY_PATH"
 npm install
 
 # iOS 의존성 설치
-cd ios
+cd "$CI_PRIMARY_REPOSITORY_PATH/ios"
 pod install


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
- `ci_post_clone.sh`에서 상대경로(`cd ../..`) 대신 `CI_PRIMARY_REPOSITORY_PATH` 환경변수로 절대경로 지정

## 🔗 관련 이슈
ref #85 

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [ ] 새로운 기능
- [ ] 버그 수정
- [ ] UI/UX 개선
- [ ] 리팩토링
- [x] 의존성 변경

## 📸 스크린샷
| 기능 | 이미지 |
|---|---|
|   |   |

## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
