### PR TITLE
[FIX] Xcode Cloud 빌드 정상화 (Podfile post_install 충돌 수정)

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -43,13 +43,5 @@ target 'HrrApp' do
         config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++20'
       end
     end
-    installer.aggregate_targets.each do |target|
-      target.user_project.targets.each do |user_target|
-        user_target.build_configurations.each do |config|
-          config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++20'
-        end
-      end
-      target.user_project.save
-    end
   end
 end


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
`post_install`의 `aggregate_targets` 블록이 Pods xcconfig와 충돌하는 문제 수정 -> `installer.pods_project.targets`만 남김

## 🔗 관련 이슈
ref #85 

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [ ] 새로운 기능
- [ ] 버그 수정
- [ ] UI/UX 개선
- [ ] 리팩토링
- [x] 의존성 변경

## 📸 스크린샷
| 기능 | 이미지 |
|---|---|
|   |   |

## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
