### PR TITLE
[FIX] Xcode Cloud 빌드 정상화 (sharp 네이티브 빌드 타임아웃 수정)

### DIFF
--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -11,7 +11,7 @@ brew install cocoapods
 
 # Node 패키지 설치
 cd "$CI_PRIMARY_REPOSITORY_PATH"
-npm install
+npm install --ignore-scripts
 
 # iOS 의존성 설치
 cd "$CI_PRIMARY_REPOSITORY_PATH/ios"


### PR DESCRIPTION
## 📝 작업 내용
<!-- 구현한 작업 내용 -->
`npm install --ignore-scripts` 적용으로 sharp 네이티브 빌드 타임아웃 오류 방지

## 🔗 관련 이슈
ref #85

## ⚙️ PR 유형
<!-- 변경사항의 종류를 선택해 주세요. -->
- [ ] 새로운 기능
- [ ] 버그 수정
- [ ] UI/UX 개선
- [ ] 리팩토링
- [x] 의존성 변경

## 📸 스크린샷
| 기능 | 이미지 |
|---|---|
|   |   |

## ⚠️ Notes
<!-- 기타 참고 사항이나 리뷰어에게 전달하고 싶은 내용 -->
